### PR TITLE
fix: TDnet P/L検出パターン修正でIFRS/US-GAAP企業の売上総利益取得を改善

### DIFF
--- a/scripts/fetch_financials.py
+++ b/scripts/fetch_financials.py
@@ -246,7 +246,7 @@ def extract_edinet_zip(zip_content: bytes) -> Optional[List[Path]]:
         Summary/
           tse-acedifsm-*.htm (決算短信サマリー - 財務ハイライト)
         Attachment/
-          *.htm (詳細財務諸表: acpl=P/L, acbs=B/S等)
+          *.htm (詳細財務諸表: *pl*=P/L, *bs*=B/S等)
           manifest.xml
 
     Returns:
@@ -270,8 +270,9 @@ def extract_edinet_zip(zip_content: bytes) -> Optional[List[Path]]:
                 print(f"    [DEBUG] TDnet Summaryファイル発見: {summary_htm.relative_to(temp_dir)}")
                 result_files.append(summary_htm)
 
-        # TDnet対応: Attachment内の損益計算書（acpl = P/L）でgross_profitを取得
-        for attachment_htm in sorted(temp_dir.rglob("*acpl*ixbrl.htm")):
+        # TDnet対応: Attachment内の損益計算書（P/L）でgross_profitを取得
+        # ファイル名パターン: J-GAAP=acedjppl, IFRS=acifrspl, US-GAAP=acusgpl
+        for attachment_htm in sorted(temp_dir.rglob("*pl*ixbrl.htm")):
             if "Attachment" in attachment_htm.parts:
                 print(f"    [DEBUG] TDnet P/Lファイル発見: {attachment_htm.relative_to(temp_dir)}")
                 result_files.append(attachment_htm)


### PR DESCRIPTION
## 概要

TDnetのAttachment P/Lファイル検出パターンを修正し、IFRS/US-GAAP採用企業の売上総利益（gross_profit）が正しく取得されるようにしました。

## 背景

従来のglobパターン `*acpl*ixbrl.htm` はJ-GAAP用ファイル名（`acedjppl`）のみにマッチし、IFRS（`acifrspl`）やUS-GAAP（`acusgpl`）のファイルが検出されませんでした。このため、IFRS/US-GAAP採用企業の売上総利益が取得できない不具合がありました。

## 変更内容

- **scripts/fetch_financials.py**
  - globパターンを `*acpl*ixbrl.htm` → `*pl*ixbrl.htm` に変更
  - J-GAAP/IFRS/US-GAAP全会計基準のP/Lファイルを検出可能に
  - コメントでファイル名パターンを明記（acedjppl, acifrspl, acusgpl）

- **tests/test_fetch_financials.py**
  - 既存テスト2件の戻り値型バグ修正（単一Pathからリスト形式へ対応）
  - 新規テスト3件追加:
    - `test_tdnet_jgaap_attachment_pl_detected` - J-GAAP P/L検出
    - `test_tdnet_ifrs_attachment_pl_detected` - IFRS P/L検出
    - `test_tdnet_summary_before_attachment` - Summary/Attachment順序確認

## テスト

pytest tests/test_fetch_financials.py::TestExtractEdinetZip -v で全テスト通過を確認済み。

## 影響範囲

- IFRS/US-GAAP採用企業の決算データ取得が正常化
- J-GAAP企業への影響なし（従来通り動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)