### PR TITLE
feat: TDnet決算短信取得を日次バッチに統合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@
 - [x] DB操作ロジック改善（`scripts/db_utils.py`）- ticker_exists()追加、FOREIGN KEY違反の事前チェック
 - [x] 包括的テストスイート（`tests/`）- 9テストファイル、実API統合テスト採用
 - [x] **EDINET決算取得の信頼性改善**（`scripts/fetch_financials.py`）- マニフェスト誤選択・引数型・半期報告書対応を修正
+- [x] **TDnet決算短信の日次バッチ統合**（`scripts/run_daily_batch.py`）- Q1/Q3法改正対応、`--skip-tdnet`フラグ追加
 
 ## 次のタスク（優先順）
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,28 @@ python3 scripts/fetch_prices.py --full
 ### 手動実行
 
 ```bash
+# 通常実行（株価 + EDINET決算 + TDnet決算短信）
 python3 scripts/run_daily_batch.py
+
+# TDnet決算短信をスキップ
+python3 scripts/run_daily_batch.py --skip-tdnet
+
+# EDINET決算をスキップ
+python3 scripts/run_daily_batch.py --skip-financials
+
+# 株価のみ取得
+python3 scripts/run_daily_batch.py --skip-financials --skip-tdnet
 ```
+
+**実行ステップ（5段階）**:
+1. データベース初期化
+2. 銘柄マスタ確認
+3. 株価取得（Yahoo Finance）
+4. 決算データ取得（EDINET: 有報・半期報）
+5. 決算短信取得（TDnet: Q1-Q4決算短信）
+
+**TDnet統合の背景**:
+2024年4月の金商法改正により、Q1/Q3四半期報告書のEDINET提出が廃止されました。そのため、Q1/Q3の決算データはTDnet決算短信からしか取得できません。TDnetは過去30日分しか取得できないため、取りこぼしを防ぐために日次バッチに統合しています。
 
 ### cron設定（毎日18:00に実行）
 


### PR DESCRIPTION
## 概要 (Overview)

2024年4月の金融商品取引法改正により、Q1/Q3四半期報告書のEDINET提出が廃止されました。そのため、Q1/Q3の決算データはTDnet決算短信からしか取得できません。TDnetは過去30日分のデータしか保持していないため、データの永久欠損を防ぐために日次バッチへの統合が必須となります。

## 変更内容 (Changes)

- **`scripts/run_daily_batch.py`**
  - TDnet決算短信取得ステップを追加（5/5ステップ）
  - `--skip-tdnet`フラグを追加（必要に応じてTDnet取得をスキップ可能）
  - 必須パッケージチェックに`bs4` (BeautifulSoup4)を追加
  - ステップ番号を4から5に更新（1/5～5/5）
  - 各ステップの説明を明確化（Yahoo Finance、EDINET、TDnet）

- **`README.md`**
  - 日次バッチの実行例を拡充（通常実行、各種スキップオプション）
  - 実行ステップの詳細説明を追加
  - TDnet統合の背景説明を追記（法改正とQ1/Q3データ取得方法の変更）

- **`CLAUDE.md`**
  - 完了タスクリストにTDnet統合を追記

## 背景 (Background)

### 法改正の影響
- **改正前**: Q1/Q3四半期報告書はEDINETに提出され、長期間アーカイブされていた
- **改正後（2024年4月～）**: Q1/Q3四半期報告書の提出義務が廃止
- **結果**: Q1/Q3データはTDnet決算短信（東証開示システム）のみで取得可能

### TDnetの制約
- **保持期間**: 過去30日間のみ
- **リスク**: 日次バッチで取得しないとデータが永久に失われる
- **対象**: Q1、Q2（中間決算）、Q3、Q4（本決算）の全四半期

### データソースの棲み分け
- **Yahoo Finance**: 日次株価データ
- **EDINET**: 有価証券報告書（年次）、半期報告書
- **TDnet**: 決算短信（Q1～Q4）← 今回統合

## テスト (Testing)

- [x] `scripts/run_daily_batch.py`が正常に実行されることを確認
- [x] `--skip-tdnet`フラグで5ステップ目がスキップされることを確認
- [x] `bs4`パッケージの事前チェックが機能することを確認
- [x] README.mdの記載内容が実装と一致していることを確認

## 関連 (Related)

- 関連スクリプト: `scripts/fetch_tdnet.py` (既存)
- 法改正情報: 2024年4月施行の金融商品取引法改正

## チェックリスト

- [x] コードは既存のコーディング規約に準拠している
- [x] ドキュメント（README.md、CLAUDE.md）を更新した
- [x] コミットメッセージは規約に従っている
- [x] 後方互換性を維持している（既存の`--skip-financials`等のフラグは維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)