### PR TITLE
feat: 決算ビューアYoYセクションに粗利YoYカラム追加

### DIFF
--- a/db/migrations/V004__add_gross_profit_yoy_to_view.sql
+++ b/db/migrations/V004__add_gross_profit_yoy_to_view.sql
@@ -1,0 +1,55 @@
+-- v_financials_yoy ビューに gross_profit_yoy_pct を追加
+DROP VIEW IF EXISTS v_financials_yoy;
+
+CREATE VIEW IF NOT EXISTS v_financials_yoy AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.fiscal_end_date,
+    f.announcement_date,
+    -- 当期の値
+    f.revenue,
+    f.gross_profit,
+    f.operating_income,
+    f.ordinary_income,
+    f.net_income,
+    f.eps,
+    -- 前年同期の値
+    LAG(f.revenue, 1) OVER w AS revenue_prev_year,
+    LAG(f.gross_profit, 1) OVER w AS gross_profit_prev_year,
+    LAG(f.operating_income, 1) OVER w AS operating_income_prev_year,
+    LAG(f.ordinary_income, 1) OVER w AS ordinary_income_prev_year,
+    LAG(f.net_income, 1) OVER w AS net_income_prev_year,
+    LAG(f.eps, 1) OVER w AS eps_prev_year,
+    -- YoY変化額
+    f.revenue - LAG(f.revenue, 1) OVER w AS revenue_yoy_change,
+    f.operating_income - LAG(f.operating_income, 1) OVER w AS operating_income_yoy_change,
+    f.net_income - LAG(f.net_income, 1) OVER w AS net_income_yoy_change,
+    -- YoY変化率（%）
+    CASE
+        WHEN LAG(f.revenue, 1) OVER w IS NOT NULL AND LAG(f.revenue, 1) OVER w != 0
+        THEN ROUND((f.revenue - LAG(f.revenue, 1) OVER w) * 100.0 / ABS(LAG(f.revenue, 1) OVER w), 2)
+        ELSE NULL
+    END AS revenue_yoy_pct,
+    CASE
+        WHEN LAG(f.gross_profit, 1) OVER w IS NOT NULL AND LAG(f.gross_profit, 1) OVER w != 0
+        THEN ROUND((f.gross_profit - LAG(f.gross_profit, 1) OVER w) * 100.0 / ABS(LAG(f.gross_profit, 1) OVER w), 2)
+        ELSE NULL
+    END AS gross_profit_yoy_pct,
+    CASE
+        WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
+        THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS operating_income_yoy_pct,
+    CASE
+        WHEN LAG(f.net_income, 1) OVER w IS NOT NULL AND LAG(f.net_income, 1) OVER w != 0
+        THEN ROUND((f.net_income - LAG(f.net_income, 1) OVER w) * 100.0 / ABS(LAG(f.net_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS net_income_yoy_pct
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WINDOW w AS (PARTITION BY f.ticker_code, f.fiscal_quarter ORDER BY f.fiscal_year)
+ORDER BY f.ticker_code, f.fiscal_year, f.fiscal_quarter;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -174,6 +174,11 @@ SELECT
         ELSE NULL
     END AS revenue_yoy_pct,
     CASE
+        WHEN LAG(f.gross_profit, 1) OVER w IS NOT NULL AND LAG(f.gross_profit, 1) OVER w != 0
+        THEN ROUND((f.gross_profit - LAG(f.gross_profit, 1) OVER w) * 100.0 / ABS(LAG(f.gross_profit, 1) OVER w), 2)
+        ELSE NULL
+    END AS gross_profit_yoy_pct,
+    CASE
         WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
         THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
         ELSE NULL

--- a/web/services/financial_service.py
+++ b/web/services/financial_service.py
@@ -96,6 +96,7 @@ def get_viewer_data(
                 "ordinary_income_qoq": None,
                 "net_income_qoq": None,
                 "revenue_yoy": None,
+                "gross_profit_yoy": None,
                 "operating_income_yoy": None,
                 "ordinary_income_yoy": None,
                 "net_income_yoy": None,
@@ -110,7 +111,8 @@ def get_viewer_data(
             if fy and fq:
                 yoy_cursor = conn.execute(
                     """
-                    SELECT revenue_yoy_pct, operating_income_yoy_pct, net_income_yoy_pct,
+                    SELECT revenue_yoy_pct, gross_profit_yoy_pct,
+                           operating_income_yoy_pct, net_income_yoy_pct,
                            ordinary_income, ordinary_income_prev_year
                     FROM v_financials_yoy
                     WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
@@ -120,6 +122,7 @@ def get_viewer_data(
                 yoy_row = yoy_cursor.fetchone()
                 if yoy_row:
                     data["revenue_yoy"] = yoy_row["revenue_yoy_pct"]
+                    data["gross_profit_yoy"] = yoy_row["gross_profit_yoy_pct"]
                     data["operating_income_yoy"] = yoy_row["operating_income_yoy_pct"]
                     data["net_income_yoy"] = yoy_row["net_income_yoy_pct"]
                     # 経常利益YoY（ビューにないので計算）

--- a/web/templates/partials/table_body.html
+++ b/web/templates/partials/table_body.html
@@ -43,9 +43,12 @@
     <td class="col-num {{ 'positive' if row.net_income_qoq is not none and row.net_income_qoq > 0 else 'negative' if row.net_income_qoq is not none and row.net_income_qoq < 0 else '' }}">
         {% if row.net_income_qoq is not none %}{{ '{:+.1f}'.format(row.net_income_qoq) }}%{% endif %}
     </td>
-    <!-- YoY 4列 -->
+    <!-- YoY 5列 -->
     <td class="col-num section-start {{ 'positive' if row.revenue_yoy is not none and row.revenue_yoy > 0 else 'negative' if row.revenue_yoy is not none and row.revenue_yoy < 0 else '' }}">
         {% if row.revenue_yoy is not none %}{{ '{:+.1f}'.format(row.revenue_yoy) }}%{% endif %}
+    </td>
+    <td class="col-num {{ 'positive' if row.gross_profit_yoy is not none and row.gross_profit_yoy > 0 else 'negative' if row.gross_profit_yoy is not none and row.gross_profit_yoy < 0 else '' }}">
+        {% if row.gross_profit_yoy is not none %}{{ '{:+.1f}'.format(row.gross_profit_yoy) }}%{% endif %}
     </td>
     <td class="col-num {{ 'positive' if row.operating_income_yoy is not none and row.operating_income_yoy > 0 else 'negative' if row.operating_income_yoy is not none and row.operating_income_yoy < 0 else '' }}">
         {% if row.operating_income_yoy is not none %}{{ '{:+.1f}'.format(row.operating_income_yoy) }}%{% endif %}
@@ -76,6 +79,6 @@
 
 {% if not rows %}
 <tr>
-    <td colspan="19" class="no-data">この日付の決算発表データはありません</td>
+    <td colspan="20" class="no-data">この日付の決算発表データはありません</td>
 </tr>
 {% endif %}

--- a/web/templates/viewer.html
+++ b/web/templates/viewer.html
@@ -59,8 +59,9 @@
                         <th class="col-num" title="営業利益 前年同期比(単独四半期)">営利QoQ</th>
                         <th class="col-num" title="経常利益 前年同期比(単独四半期)">経利QoQ</th>
                         <th class="col-num" title="純利益 前年同期比(単独四半期)">純利QoQ</th>
-                        <!-- YoY 4列 -->
+                        <!-- YoY 5列 -->
                         <th class="col-num section-start" title="売上高 前年同期比(累計)">売上YoY</th>
+                        <th class="col-num" title="売上総利益 前年同期比(累計)">粗利YoY</th>
                         <th class="col-num" title="営業利益 前年同期比(累計)">営利YoY</th>
                         <th class="col-num" title="経常利益 前年同期比(累計)">経利YoY</th>
                         <th class="col-num" title="純利益 前年同期比(累計)">純利YoY</th>


### PR DESCRIPTION
## Summary
- 決算ビューアのYoYセクションに粗利YoY（売上総利益 前年同期比）カラムを追加
- QoQセクションには既にある粗利比較がYoYセクションに欠けていたため、売上YoYと営利YoYの間に配置
- DBビュー `v_financials_yoy` に `gross_profit_yoy_pct` を追加するマイグレーション含む

## Test plan
- [x] マイグレーション正常実行確認
- [x] 既存テスト通過（16 passed、1 failed は既存の無関係なテスト）
- [x] ブラウザでヘッダー「粗利YoY」表示確認
- [x] テーブル行が20カラムに正しく拡張されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)