### PR TITLE
fix: 本番環境の.envとvenv削除を防ぐためrsyncに除外設定を追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
             --exclude '*.pem' \
             --exclude 'db/stock_agent.db' \
             --exclude 'logs/*' \
+            --exclude '.env' \
+            --exclude 'venv' \
             -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
             ./ ${{ env.VM_USER }}@${{ env.VM_HOST }}:${{ env.DEPLOY_PATH }}/
 


### PR DESCRIPTION
## 概要

CI/CDのデプロイワークフローにおいて、`rsync --delete` 実行時に本番環境の `.env`（APIキー等の機密情報）と `venv`（仮想環境）が削除されてしまうバグを修正しました。

## 変更内容

- `.github/workflows/deploy.yml` の rsync コマンドに以下の除外設定を追加
  - `--exclude '.env'`
  - `--exclude 'venv'`

## 修正理由

- `rsync --delete` は転送元に存在しないファイルを転送先から削除する
- `.env` と `venv` はリポジトリに含まれないため、デプロイ時に本番環境から削除されていた
- `.env` にはEDINET_API_KEY等の機密情報が含まれており、削除されるとバッチが動作しなくなる
- `venv` は本番環境で個別に構築されるため、rsyncの対象外とすべき

## テスト

- ワークフローファイルの構文確認済み
- 除外設定の追加により、既存の除外パターンとの整合性を確認