### PR TITLE
fix: 決算期変更銘柄のデータ上書き問題を修正

### DIFF
--- a/db/migrations/V007__add_fiscal_end_date_to_unique.rollback.sql
+++ b/db/migrations/V007__add_fiscal_end_date_to_unique.rollback.sql
@@ -1,0 +1,201 @@
+-- V007 ロールバック: fiscal_end_date を UNIQUE 制約から除外
+
+-- ステップ1: 旧テーブル構造を再作成
+CREATE TABLE financials_old (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker_code TEXT NOT NULL,
+    fiscal_year TEXT NOT NULL,
+    fiscal_quarter TEXT,
+    fiscal_end_date TEXT,  -- NOT NULL 制約なし
+    announcement_date TEXT,
+    announcement_time TEXT,
+    revenue REAL,
+    gross_profit REAL,
+    operating_income REAL,
+    ordinary_income REAL,
+    net_income REAL,
+    eps REAL,
+    currency TEXT DEFAULT 'JPY',
+    unit TEXT DEFAULT 'million',
+    source TEXT,
+    edinet_doc_id TEXT,
+    pdf_path TEXT,
+    created_at TEXT DEFAULT (datetime('now', 'localtime')),
+    updated_at TEXT DEFAULT (datetime('now', 'localtime')),
+    UNIQUE(ticker_code, fiscal_year, fiscal_quarter),
+    FOREIGN KEY (ticker_code) REFERENCES companies(ticker_code)
+);
+
+-- ステップ2: データコピー
+INSERT INTO financials_old (
+    id, ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+    announcement_date, announcement_time,
+    revenue, gross_profit, operating_income, ordinary_income, net_income, eps,
+    currency, unit, source, edinet_doc_id, pdf_path,
+    created_at, updated_at
+)
+SELECT
+    id, ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+    announcement_date, announcement_time,
+    revenue, gross_profit, operating_income, ordinary_income, net_income, eps,
+    currency, unit, source, edinet_doc_id, pdf_path,
+    created_at, updated_at
+FROM financials;
+
+-- ステップ3: 入替
+DROP TABLE financials;
+ALTER TABLE financials_old RENAME TO financials;
+
+-- ステップ4: インデックス再作成
+CREATE INDEX IF NOT EXISTS idx_fin_ticker ON financials(ticker_code);
+CREATE INDEX IF NOT EXISTS idx_fin_year ON financials(fiscal_year);
+CREATE INDEX IF NOT EXISTS idx_fin_announce ON financials(announcement_date);
+
+-- ステップ5: ビュー再作成（V006以前の定義）
+DROP VIEW IF EXISTS v_financials_yoy;
+CREATE VIEW IF NOT EXISTS v_financials_yoy AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.fiscal_end_date,
+    f.announcement_date,
+    f.revenue,
+    f.gross_profit,
+    f.operating_income,
+    f.ordinary_income,
+    f.net_income,
+    f.eps,
+    LAG(f.revenue, 1) OVER w AS revenue_prev_year,
+    LAG(f.gross_profit, 1) OVER w AS gross_profit_prev_year,
+    LAG(f.operating_income, 1) OVER w AS operating_income_prev_year,
+    LAG(f.ordinary_income, 1) OVER w AS ordinary_income_prev_year,
+    LAG(f.net_income, 1) OVER w AS net_income_prev_year,
+    LAG(f.eps, 1) OVER w AS eps_prev_year,
+    f.revenue - LAG(f.revenue, 1) OVER w AS revenue_yoy_change,
+    f.operating_income - LAG(f.operating_income, 1) OVER w AS operating_income_yoy_change,
+    f.net_income - LAG(f.net_income, 1) OVER w AS net_income_yoy_change,
+    CASE
+        WHEN LAG(f.revenue, 1) OVER w IS NOT NULL AND LAG(f.revenue, 1) OVER w != 0
+        THEN ROUND((f.revenue - LAG(f.revenue, 1) OVER w) * 100.0 / ABS(LAG(f.revenue, 1) OVER w), 2)
+        ELSE NULL
+    END AS revenue_yoy_pct,
+    CASE
+        WHEN LAG(f.gross_profit, 1) OVER w IS NOT NULL AND LAG(f.gross_profit, 1) OVER w != 0
+        THEN ROUND((f.gross_profit - LAG(f.gross_profit, 1) OVER w) * 100.0 / ABS(LAG(f.gross_profit, 1) OVER w), 2)
+        ELSE NULL
+    END AS gross_profit_yoy_pct,
+    CASE
+        WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
+        THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS operating_income_yoy_pct
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WINDOW w AS (PARTITION BY f.ticker_code, f.fiscal_quarter ORDER BY f.fiscal_year)
+ORDER BY f.ticker_code, f.fiscal_year, f.fiscal_quarter;
+
+DROP VIEW IF EXISTS v_financials_qoq;
+CREATE VIEW IF NOT EXISTS v_financials_qoq AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.fiscal_end_date,
+    f.announcement_date,
+    f.revenue,
+    f.operating_income,
+    f.net_income,
+    f.eps,
+    LAG(f.revenue, 1) OVER w AS revenue_prev_quarter,
+    LAG(f.operating_income, 1) OVER w AS operating_income_prev_quarter,
+    LAG(f.net_income, 1) OVER w AS net_income_prev_quarter,
+    LAG(f.eps, 1) OVER w AS eps_prev_quarter,
+    f.revenue - LAG(f.revenue, 1) OVER w AS revenue_qoq_change,
+    f.operating_income - LAG(f.operating_income, 1) OVER w AS operating_income_qoq_change,
+    f.net_income - LAG(f.net_income, 1) OVER w AS net_income_qoq_change,
+    CASE
+        WHEN LAG(f.revenue, 1) OVER w IS NOT NULL AND LAG(f.revenue, 1) OVER w != 0
+        THEN ROUND((f.revenue - LAG(f.revenue, 1) OVER w) * 100.0 / ABS(LAG(f.revenue, 1) OVER w), 2)
+        ELSE NULL
+    END AS revenue_qoq_pct,
+    CASE
+        WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
+        THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS operating_income_qoq_pct
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WHERE f.fiscal_quarter != 'FY'
+WINDOW w AS (
+    PARTITION BY f.ticker_code
+    ORDER BY f.fiscal_year,
+             CASE f.fiscal_quarter
+                WHEN 'Q1' THEN 1
+                WHEN 'Q2' THEN 2
+                WHEN 'Q3' THEN 3
+                WHEN 'Q4' THEN 4
+             END
+)
+ORDER BY f.ticker_code, f.fiscal_year, f.fiscal_quarter;
+
+DROP VIEW IF EXISTS v_financials_standalone_quarter;
+CREATE VIEW IF NOT EXISTS v_financials_standalone_quarter AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    CASE f.fiscal_quarter
+        WHEN 'FY' THEN 'Q4'
+        ELSE f.fiscal_quarter
+    END AS fiscal_quarter,
+    f.announcement_date,
+    f.announcement_time,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.revenue
+        ELSE f.revenue - COALESCE(prev.revenue, 0)
+    END AS revenue_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.gross_profit
+        ELSE f.gross_profit - COALESCE(prev.gross_profit, 0)
+    END AS gross_profit_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.operating_income
+        ELSE f.operating_income - COALESCE(prev.operating_income, 0)
+    END AS operating_income_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.ordinary_income
+        ELSE f.ordinary_income - COALESCE(prev.ordinary_income, 0)
+    END AS ordinary_income_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.net_income
+        ELSE f.net_income - COALESCE(prev.net_income, 0)
+    END AS net_income_standalone,
+    f.revenue AS revenue_cumulative,
+    f.gross_profit AS gross_profit_cumulative,
+    f.operating_income AS operating_income_cumulative,
+    f.ordinary_income AS ordinary_income_cumulative,
+    f.net_income AS net_income_cumulative,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN 1
+        ELSE CASE WHEN prev.id IS NOT NULL THEN 1 ELSE 0 END
+    END AS has_prev_quarter
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+LEFT JOIN financials prev ON (
+    f.ticker_code = prev.ticker_code
+    AND f.fiscal_year = prev.fiscal_year
+    AND prev.fiscal_quarter = CASE f.fiscal_quarter
+        WHEN 'Q2' THEN 'Q1'
+        WHEN 'Q3' THEN 'Q2'
+        WHEN 'Q4' THEN 'Q3'
+        WHEN 'FY' THEN 'Q3'
+        ELSE NULL
+    END
+)
+WHERE f.fiscal_quarter IN ('Q1', 'Q2', 'Q3', 'Q4', 'FY');

--- a/db/migrations/V007__add_fiscal_end_date_to_unique.sql
+++ b/db/migrations/V007__add_fiscal_end_date_to_unique.sql
@@ -1,0 +1,260 @@
+-- V007: fiscal_end_date を UNIQUE 制約に追加（決算期変更対応）
+-- SQLite は ALTER TABLE で制約変更不可のため、テーブル再作成方式
+
+-- ステップ0: ビューを先に削除（テーブル削除前に必要）
+DROP VIEW IF EXISTS v_financials_yoy;
+DROP VIEW IF EXISTS v_financials_qoq;
+DROP VIEW IF EXISTS v_financials_standalone_quarter;
+DROP VIEW IF EXISTS v_latest_financials;
+DROP VIEW IF EXISTS v_missing_financials;
+
+-- ステップ1: 既存NULLのfiscal_end_dateを補完
+UPDATE financials
+SET fiscal_end_date = fiscal_year || '-12-31'
+WHERE fiscal_end_date IS NULL;
+
+-- ステップ2: 新テーブル作成（NOT NULL + 4カラムUNIQUE）
+CREATE TABLE financials_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ticker_code TEXT NOT NULL,
+    fiscal_year TEXT NOT NULL,
+    fiscal_quarter TEXT,
+    fiscal_end_date TEXT NOT NULL,  -- NOT NULL に変更
+    announcement_date TEXT,
+    announcement_time TEXT,
+    revenue REAL,
+    gross_profit REAL,
+    operating_income REAL,
+    ordinary_income REAL,
+    net_income REAL,
+    eps REAL,
+    currency TEXT DEFAULT 'JPY',
+    unit TEXT DEFAULT 'million',
+    source TEXT,
+    edinet_doc_id TEXT,
+    pdf_path TEXT,
+    created_at TEXT DEFAULT (datetime('now', 'localtime')),
+    updated_at TEXT DEFAULT (datetime('now', 'localtime')),
+    UNIQUE(ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date),
+    FOREIGN KEY (ticker_code) REFERENCES companies(ticker_code)
+);
+
+-- ステップ3: データコピー
+INSERT INTO financials_new (
+    id, ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+    announcement_date, announcement_time,
+    revenue, gross_profit, operating_income, ordinary_income, net_income, eps,
+    currency, unit, source, edinet_doc_id, pdf_path,
+    created_at, updated_at
+)
+SELECT
+    id, ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+    announcement_date, announcement_time,
+    revenue, gross_profit, operating_income, ordinary_income, net_income, eps,
+    currency, unit, source, edinet_doc_id, pdf_path,
+    created_at, updated_at
+FROM financials;
+
+-- ステップ4: 入替
+DROP TABLE financials;
+ALTER TABLE financials_new RENAME TO financials;
+
+-- ステップ5: インデックス再作成
+CREATE INDEX IF NOT EXISTS idx_fin_ticker ON financials(ticker_code);
+CREATE INDEX IF NOT EXISTS idx_fin_year ON financials(fiscal_year);
+CREATE INDEX IF NOT EXISTS idx_fin_announce ON financials(announcement_date);
+CREATE INDEX IF NOT EXISTS idx_fin_end_date ON financials(fiscal_end_date);
+
+-- ステップ6: ビュー再作成
+-- v_financials_yoy: ORDER BY を fiscal_end_date に変更
+CREATE VIEW IF NOT EXISTS v_financials_yoy AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.fiscal_end_date,
+    f.announcement_date,
+    -- 当期の値
+    f.revenue,
+    f.gross_profit,
+    f.operating_income,
+    f.ordinary_income,
+    f.net_income,
+    f.eps,
+    -- 前年同期の値
+    LAG(f.revenue, 1) OVER w AS revenue_prev_year,
+    LAG(f.gross_profit, 1) OVER w AS gross_profit_prev_year,
+    LAG(f.operating_income, 1) OVER w AS operating_income_prev_year,
+    LAG(f.ordinary_income, 1) OVER w AS ordinary_income_prev_year,
+    LAG(f.net_income, 1) OVER w AS net_income_prev_year,
+    LAG(f.eps, 1) OVER w AS eps_prev_year,
+    -- YoY変化額
+    f.revenue - LAG(f.revenue, 1) OVER w AS revenue_yoy_change,
+    f.operating_income - LAG(f.operating_income, 1) OVER w AS operating_income_yoy_change,
+    f.net_income - LAG(f.net_income, 1) OVER w AS net_income_yoy_change,
+    -- YoY変化率（%）
+    CASE
+        WHEN LAG(f.revenue, 1) OVER w IS NOT NULL AND LAG(f.revenue, 1) OVER w != 0
+        THEN ROUND((f.revenue - LAG(f.revenue, 1) OVER w) * 100.0 / ABS(LAG(f.revenue, 1) OVER w), 2)
+        ELSE NULL
+    END AS revenue_yoy_pct,
+    CASE
+        WHEN LAG(f.gross_profit, 1) OVER w IS NOT NULL AND LAG(f.gross_profit, 1) OVER w != 0
+        THEN ROUND((f.gross_profit - LAG(f.gross_profit, 1) OVER w) * 100.0 / ABS(LAG(f.gross_profit, 1) OVER w), 2)
+        ELSE NULL
+    END AS gross_profit_yoy_pct,
+    CASE
+        WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
+        THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS operating_income_yoy_pct,
+    CASE
+        WHEN LAG(f.net_income, 1) OVER w IS NOT NULL AND LAG(f.net_income, 1) OVER w != 0
+        THEN ROUND((f.net_income - LAG(f.net_income, 1) OVER w) * 100.0 / ABS(LAG(f.net_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS net_income_yoy_pct
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WINDOW w AS (PARTITION BY f.ticker_code, f.fiscal_quarter ORDER BY f.fiscal_end_date)
+ORDER BY f.ticker_code, f.fiscal_end_date, f.fiscal_quarter;
+
+-- v_financials_qoq: ORDER BY を fiscal_end_date に変更
+CREATE VIEW IF NOT EXISTS v_financials_qoq AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.fiscal_end_date,
+    f.announcement_date,
+    -- 当期の値
+    f.revenue,
+    f.operating_income,
+    f.net_income,
+    f.eps,
+    -- 前四半期の値
+    LAG(f.revenue, 1) OVER w AS revenue_prev_quarter,
+    LAG(f.operating_income, 1) OVER w AS operating_income_prev_quarter,
+    LAG(f.net_income, 1) OVER w AS net_income_prev_quarter,
+    LAG(f.eps, 1) OVER w AS eps_prev_quarter,
+    -- QoQ変化額
+    f.revenue - LAG(f.revenue, 1) OVER w AS revenue_qoq_change,
+    f.operating_income - LAG(f.operating_income, 1) OVER w AS operating_income_qoq_change,
+    f.net_income - LAG(f.net_income, 1) OVER w AS net_income_qoq_change,
+    -- QoQ変化率（%）
+    CASE
+        WHEN LAG(f.revenue, 1) OVER w IS NOT NULL AND LAG(f.revenue, 1) OVER w != 0
+        THEN ROUND((f.revenue - LAG(f.revenue, 1) OVER w) * 100.0 / ABS(LAG(f.revenue, 1) OVER w), 2)
+        ELSE NULL
+    END AS revenue_qoq_pct,
+    CASE
+        WHEN LAG(f.operating_income, 1) OVER w IS NOT NULL AND LAG(f.operating_income, 1) OVER w != 0
+        THEN ROUND((f.operating_income - LAG(f.operating_income, 1) OVER w) * 100.0 / ABS(LAG(f.operating_income, 1) OVER w), 2)
+        ELSE NULL
+    END AS operating_income_qoq_pct
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WHERE f.fiscal_quarter != 'FY'
+WINDOW w AS (
+    PARTITION BY f.ticker_code
+    ORDER BY f.fiscal_end_date
+)
+ORDER BY f.ticker_code, f.fiscal_end_date, f.fiscal_quarter;
+
+-- v_financials_standalone_quarter: V006の定義をそのまま再作成
+CREATE VIEW IF NOT EXISTS v_financials_standalone_quarter AS
+SELECT
+    f.id,
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    CASE f.fiscal_quarter
+        WHEN 'FY' THEN 'Q4'
+        ELSE f.fiscal_quarter
+    END AS fiscal_quarter,
+    f.announcement_date,
+    f.announcement_time,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.revenue
+        ELSE f.revenue - COALESCE(prev.revenue, 0)
+    END AS revenue_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.gross_profit
+        ELSE f.gross_profit - COALESCE(prev.gross_profit, 0)
+    END AS gross_profit_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.operating_income
+        ELSE f.operating_income - COALESCE(prev.operating_income, 0)
+    END AS operating_income_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.ordinary_income
+        ELSE f.ordinary_income - COALESCE(prev.ordinary_income, 0)
+    END AS ordinary_income_standalone,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN f.net_income
+        ELSE f.net_income - COALESCE(prev.net_income, 0)
+    END AS net_income_standalone,
+    f.revenue AS revenue_cumulative,
+    f.gross_profit AS gross_profit_cumulative,
+    f.operating_income AS operating_income_cumulative,
+    f.ordinary_income AS ordinary_income_cumulative,
+    f.net_income AS net_income_cumulative,
+    CASE f.fiscal_quarter
+        WHEN 'Q1' THEN 1
+        ELSE CASE WHEN prev.id IS NOT NULL THEN 1 ELSE 0 END
+    END AS has_prev_quarter
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+LEFT JOIN financials prev ON (
+    f.ticker_code = prev.ticker_code
+    AND f.fiscal_year = prev.fiscal_year
+    AND prev.fiscal_quarter = CASE f.fiscal_quarter
+        WHEN 'Q2' THEN 'Q1'
+        WHEN 'Q3' THEN 'Q2'
+        WHEN 'Q4' THEN 'Q3'
+        WHEN 'FY' THEN 'Q3'
+        ELSE NULL
+    END
+)
+WHERE f.fiscal_quarter IN ('Q1', 'Q2', 'Q3', 'Q4', 'FY');
+
+-- v_latest_financials: 再作成
+CREATE VIEW IF NOT EXISTS v_latest_financials AS
+SELECT
+    f.*,
+    c.company_name,
+    c.market_segment,
+    c.sector_33
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WHERE f.announcement_date = (
+    SELECT MAX(announcement_date) FROM financials WHERE ticker_code = f.ticker_code
+);
+
+-- v_missing_financials: 再作成
+CREATE VIEW IF NOT EXISTS v_missing_financials AS
+SELECT
+    f.ticker_code,
+    c.company_name,
+    f.fiscal_year,
+    f.fiscal_quarter,
+    f.source,
+    f.announcement_date,
+    CASE WHEN f.revenue IS NULL THEN 1 ELSE 0 END AS missing_revenue,
+    CASE WHEN f.gross_profit IS NULL THEN 1 ELSE 0 END AS missing_gross_profit,
+    CASE WHEN f.operating_income IS NULL THEN 1 ELSE 0 END AS missing_operating_income,
+    CASE WHEN f.ordinary_income IS NULL THEN 1 ELSE 0 END AS missing_ordinary_income,
+    CASE WHEN f.net_income IS NULL THEN 1 ELSE 0 END AS missing_net_income,
+    CASE WHEN f.eps IS NULL THEN 1 ELSE 0 END AS missing_eps
+FROM financials f
+INNER JOIN companies c ON f.ticker_code = c.ticker_code
+WHERE f.revenue IS NULL
+   OR f.gross_profit IS NULL
+   OR f.operating_income IS NULL
+   OR f.ordinary_income IS NULL
+   OR f.net_income IS NULL
+   OR f.eps IS NULL
+ORDER BY f.announcement_date DESC, f.ticker_code;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ stock_agent/
 | companies | 銘柄マスタ | ticker_code |
 | daily_prices | 日次株価（OHLCV+調整後終値） | id, UNIQUE(ticker_code, trade_date) |
 | stock_splits | 株式分割情報 | id, UNIQUE(ticker_code, split_date) |
-| financials | 決算データ（announcement_time追加） | id, UNIQUE(ticker_code, fiscal_year, fiscal_quarter) |
+| financials | 決算データ（fiscal_end_date必須化） | id, UNIQUE(ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date) |
 | announcements | 適時開示（決算/業績修正/配当） | id, UNIQUE(ticker_code, announcement_date, type, fiscal_year, fiscal_quarter) |
 | management_forecasts | 業績予想 | id, UNIQUE(ticker_code, fiscal_year, fiscal_quarter, announced_date) |
 | consensus_estimates | コンセンサス予想（スキーマのみ） | id, UNIQUE(ticker_code, fiscal_year, fiscal_quarter, as_of_date) |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,6 +106,7 @@ def sample_financials(sample_company):
                 "operating_income": 10.0,
                 "net_income": 7.0,
                 "eps": 50.0,
+                "fiscal_end_date": "2022-06-30",
             },
         ),
         (
@@ -116,6 +117,7 @@ def sample_financials(sample_company):
                 "operating_income": 12.0,
                 "net_income": 8.0,
                 "eps": 55.0,
+                "fiscal_end_date": "2022-09-30",
             },
         ),
     ]

--- a/tests/test_fetch_tdnet.py
+++ b/tests/test_fetch_tdnet.py
@@ -11,7 +11,7 @@ BASE_DIR = Path(__file__).parent.parent
 sys.path.insert(0, str(BASE_DIR / "scripts"))
 sys.path.insert(0, str(BASE_DIR / "lib"))
 
-from fetch_tdnet import detect_fiscal_period
+from fetch_tdnet import detect_fiscal_period, detect_fiscal_end_date_from_title
 from fetch_financials import _wareki_to_seireki
 from db_utils import get_connection, insert_financial
 
@@ -227,6 +227,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=100.0,
             source='TDnet'
         )
@@ -249,6 +250,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=100.0,
             source='TDnet'
         )
@@ -258,6 +260,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=200.0,
             source='TDnet'
         )
@@ -278,6 +281,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=100.0,
             source='EDINET'
         )
@@ -287,6 +291,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=200.0,
             source='TDnet'
         )
@@ -308,6 +313,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=100.0,
             source='TDnet'
         )
@@ -317,6 +323,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=200.0,
             source='EDINET'
         )
@@ -338,6 +345,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=100.0,
             source='EDINET'
         )
@@ -347,6 +355,7 @@ class TestDataSourcePriority:
             ticker_code='TEST',
             fiscal_year='2024',
             fiscal_quarter='Q1',
+            fiscal_end_date='2023-06-30',
             revenue=200.0,
             source='EDINET'
         )
@@ -359,6 +368,38 @@ class TestDataSourcePriority:
             )
             row = cursor.fetchone()
             assert row['revenue'] == 200.0
+
+
+class TestDetectFiscalEndDateFromTitle:
+    """タイトルからfiscal_end_date推定のテスト"""
+
+    def test_march_fy_q1(self):
+        assert detect_fiscal_end_date_from_title(
+            "2024年3月期 第1四半期決算短信", "2024", "Q1") == "2023-06-30"
+
+    def test_march_fy_fy(self):
+        assert detect_fiscal_end_date_from_title(
+            "2024年3月期 通期決算短信", "2024", "FY") == "2024-03-31"
+
+    def test_december_fy_fy(self):
+        assert detect_fiscal_end_date_from_title(
+            "2024年12月期 通期決算短信", "2024", "FY") == "2024-12-31"
+
+    def test_december_fy_q1(self):
+        assert detect_fiscal_end_date_from_title(
+            "2025年12月期 第1四半期決算短信", "2025", "Q1") == "2025-03-31"
+
+    def test_february_fy_leap_year(self):
+        assert detect_fiscal_end_date_from_title(
+            "2024年2月期 通期決算短信", "2024", "FY") == "2024-02-29"
+
+    def test_fullwidth_digits(self):
+        assert detect_fiscal_end_date_from_title(
+            "２０２６年３月期 通期決算短信", "2026", "FY") == "2026-03-31"
+
+    def test_no_match_returns_none(self):
+        assert detect_fiscal_end_date_from_title(
+            "決算短信", "2024", "FY") is None
 
 
 # TdnetClient のテストは実際のHTTPリクエストが必要なため、

--- a/tests/test_financial_history.py
+++ b/tests/test_financial_history.py
@@ -19,18 +19,18 @@ def ticker_with_3yr_data(test_db):
 
     data = [
         # 2022年度
-        ("2022", "Q1", {"revenue": 80.0, "operating_income": 8.0, "ordinary_income": 7.0, "net_income": 5.0, "eps": 40.0}),
-        ("2022", "Q2", {"revenue": 170.0, "operating_income": 17.0, "ordinary_income": 15.0, "net_income": 11.0, "eps": 85.0}),
-        ("2022", "FY", {"revenue": 400.0, "operating_income": 40.0, "ordinary_income": 36.0, "net_income": 28.0, "eps": 180.0}),
+        ("2022", "Q1", {"revenue": 80.0, "operating_income": 8.0, "ordinary_income": 7.0, "net_income": 5.0, "eps": 40.0, "fiscal_end_date": "2021-06-30"}),
+        ("2022", "Q2", {"revenue": 170.0, "operating_income": 17.0, "ordinary_income": 15.0, "net_income": 11.0, "eps": 85.0, "fiscal_end_date": "2021-09-30"}),
+        ("2022", "FY", {"revenue": 400.0, "operating_income": 40.0, "ordinary_income": 36.0, "net_income": 28.0, "eps": 180.0, "fiscal_end_date": "2022-03-31"}),
         # 2023年度
-        ("2023", "Q1", {"revenue": 100.0, "operating_income": 10.0, "ordinary_income": 9.0, "net_income": 7.0, "eps": 50.0}),
-        ("2023", "Q2", {"revenue": 200.0, "operating_income": 20.0, "ordinary_income": 18.0, "net_income": 14.0, "eps": 100.0}),
-        ("2023", "Q3", {"revenue": 310.0, "operating_income": 31.0, "ordinary_income": 28.0, "net_income": 21.0, "eps": 150.0}),
-        ("2023", "FY", {"revenue": 450.0, "operating_income": 50.0, "ordinary_income": 45.0, "net_income": 35.0, "eps": 200.0}),
+        ("2023", "Q1", {"revenue": 100.0, "operating_income": 10.0, "ordinary_income": 9.0, "net_income": 7.0, "eps": 50.0, "fiscal_end_date": "2022-06-30"}),
+        ("2023", "Q2", {"revenue": 200.0, "operating_income": 20.0, "ordinary_income": 18.0, "net_income": 14.0, "eps": 100.0, "fiscal_end_date": "2022-09-30"}),
+        ("2023", "Q3", {"revenue": 310.0, "operating_income": 31.0, "ordinary_income": 28.0, "net_income": 21.0, "eps": 150.0, "fiscal_end_date": "2022-12-31"}),
+        ("2023", "FY", {"revenue": 450.0, "operating_income": 50.0, "ordinary_income": 45.0, "net_income": 35.0, "eps": 200.0, "fiscal_end_date": "2023-03-31"}),
         # 2024年度
-        ("2024", "Q1", {"revenue": 120.0, "operating_income": 14.0, "ordinary_income": 12.0, "net_income": 9.0, "eps": 60.0}),
-        ("2024", "Q2", {"revenue": 240.0, "operating_income": 28.0, "ordinary_income": 24.0, "net_income": 18.0, "eps": 120.0}),
-        ("2024", "FY", {"revenue": 530.0, "operating_income": 60.0, "ordinary_income": 55.0, "net_income": 42.0, "eps": 250.0}),
+        ("2024", "Q1", {"revenue": 120.0, "operating_income": 14.0, "ordinary_income": 12.0, "net_income": 9.0, "eps": 60.0, "fiscal_end_date": "2023-06-30"}),
+        ("2024", "Q2", {"revenue": 240.0, "operating_income": 28.0, "ordinary_income": 24.0, "net_income": 18.0, "eps": 120.0, "fiscal_end_date": "2023-09-30"}),
+        ("2024", "FY", {"revenue": 530.0, "operating_income": 60.0, "ordinary_income": 55.0, "net_income": 42.0, "eps": 250.0, "fiscal_end_date": "2024-03-31"}),
     ]
     for year, quarter, vals in data:
         insert_financial(ticker, year, quarter, **vals, source="TEST")
@@ -84,17 +84,20 @@ class TestCumulativeLatestQuarter:
                 ticker, year, "Q2",
                 revenue=float(int(year) * 10), operating_income=10.0,
                 net_income=5.0, eps=1.0, source="TEST",
+                fiscal_end_date=f"{int(year)-1}-09-30",
             )
             insert_financial(
                 ticker, year, "FY",
                 revenue=float(int(year) * 20), operating_income=20.0,
                 net_income=10.0, eps=2.0, source="TEST",
+                fiscal_end_date=f"{year}-03-31",
             )
         # Q2を最新にするため2025 Q2を追加
         insert_financial(
             ticker, "2025", "Q2",
             revenue=25000.0, operating_income=100.0,
             net_income=50.0, eps=10.0, source="TEST",
+            fiscal_end_date="2024-09-30",
         )
         result = get_financial_history(ticker)
         assert result["cumulative_title"] == "2Q累計"
@@ -110,6 +113,7 @@ class TestCumulativeLatestQuarter:
                 ticker, str(year), "FY",
                 revenue=float(year), operating_income=10.0,
                 net_income=5.0, eps=1.0, source="TEST",
+                fiscal_end_date=f"{year}-03-31",
             )
         result = get_financial_history(ticker)
         assert len(result["cumulative"]) == 3

--- a/tests/test_financial_views.py
+++ b/tests/test_financial_views.py
@@ -23,22 +23,22 @@ def setup_test_data(test_db):
     test_data = [
         # 2023年度
         ('9999', '2023', 'Q1', {'revenue': 100.0, 'operating_income': 10.0, 'net_income': 7.0, 'eps': 50.0,
-                                 'gross_profit': 30.0, 'ordinary_income': 9.0}),
+                                 'gross_profit': 30.0, 'ordinary_income': 9.0, 'fiscal_end_date': '2022-06-30'}),
         ('9999', '2023', 'Q2', {'revenue': 110.0, 'operating_income': 12.0, 'net_income': 8.0, 'eps': 55.0,
-                                 'gross_profit': 33.0, 'ordinary_income': 11.0}),
+                                 'gross_profit': 33.0, 'ordinary_income': 11.0, 'fiscal_end_date': '2022-09-30'}),
         ('9999', '2023', 'Q3', {'revenue': 120.0, 'operating_income': 15.0, 'net_income': 10.0, 'eps': 60.0,
-                                 'gross_profit': 36.0, 'ordinary_income': 13.0}),
+                                 'gross_profit': 36.0, 'ordinary_income': 13.0, 'fiscal_end_date': '2022-12-31'}),
         ('9999', '2023', 'FY', {'revenue': 450.0, 'operating_income': 50.0, 'net_income': 35.0, 'eps': 200.0,
-                                 'gross_profit': 135.0, 'ordinary_income': 45.0}),
+                                 'gross_profit': 135.0, 'ordinary_income': 45.0, 'fiscal_end_date': '2023-03-31'}),
         # 2024年度
         ('9999', '2024', 'Q1', {'revenue': 120.0, 'operating_income': 14.0, 'net_income': 9.0, 'eps': 60.0,
-                                 'gross_profit': 36.0, 'ordinary_income': 12.0}),
+                                 'gross_profit': 36.0, 'ordinary_income': 12.0, 'fiscal_end_date': '2023-06-30'}),
         ('9999', '2024', 'Q2', {'revenue': 130.0, 'operating_income': 16.0, 'net_income': 11.0, 'eps': 70.0,
-                                 'gross_profit': 39.0, 'ordinary_income': 14.0}),
+                                 'gross_profit': 39.0, 'ordinary_income': 14.0, 'fiscal_end_date': '2023-09-30'}),
         ('9999', '2024', 'Q3', {'revenue': 140.0, 'operating_income': 18.0, 'net_income': 12.0, 'eps': 75.0,
-                                 'gross_profit': 42.0, 'ordinary_income': 16.0}),
+                                 'gross_profit': 42.0, 'ordinary_income': 16.0, 'fiscal_end_date': '2023-12-31'}),
         ('9999', '2024', 'FY', {'revenue': 530.0, 'operating_income': 60.0, 'net_income': 42.0, 'eps': 250.0,
-                                 'gross_profit': 159.0, 'ordinary_income': 55.0}),
+                                 'gross_profit': 159.0, 'ordinary_income': 55.0, 'fiscal_end_date': '2024-03-31'}),
     ]
 
     for ticker, year, quarter, data in test_data:

--- a/tests/test_fiscal_year_change_web.py
+++ b/tests/test_fiscal_year_change_web.py
@@ -1,0 +1,146 @@
+"""
+決算期変更銘柄のWeb層クエリテスト
+
+同一(ticker, fiscal_year, fiscal_quarter)に複数レコードが存在する場合、
+最新のfiscal_end_dateのレコードを優先して返すことを確認。
+"""
+import pytest
+import sys
+import sqlite3
+from pathlib import Path
+from datetime import date
+
+# scriptsディレクトリをパスに追加
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from db_utils import get_connection, upsert_company
+from web.services.financial_service import get_viewer_data, get_detail_data
+
+
+@pytest.fixture(autouse=True)
+def setup_fiscal_change_data(test_db):
+    """決算期変更銘柄のテストデータ（175A）をセットアップ"""
+    # テスト用銘柄を登録
+    upsert_company('175A', '決算期変更テスト株式会社')
+
+    # 同一(ticker, year, quarter)に複数レコードを投入
+    # fiscal_end_dateが異なる（決算期変更前後）
+    with get_connection() as conn:
+        # 旧決算期（12月期）の2024年度Q1: 2024-03-31期末
+        conn.execute(
+            """
+            INSERT INTO financials (
+                ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+                announcement_date, revenue, operating_income, net_income, eps, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                '175A', '2024', 'Q1', '2024-03-31',
+                '2024-05-10', 100.0, 10.0, 7.0, 50.0, 'TEST_OLD'
+            ]
+        )
+
+        # 新決算期（3月期）の2024年度Q1: 2024-06-30期末（決算期変更後）
+        # 最新のfiscal_end_dateなのでこちらが優先されるべき
+        conn.execute(
+            """
+            INSERT INTO financials (
+                ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+                announcement_date, revenue, operating_income, net_income, eps, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                '175A', '2024', 'Q1', '2024-06-30',
+                '2024-08-10', 150.0, 20.0, 15.0, 80.0, 'TEST_NEW'
+            ]
+        )
+
+        # 前年同期（YoY計算用）
+        conn.execute(
+            """
+            INSERT INTO financials (
+                ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date,
+                announcement_date, revenue, operating_income, net_income, eps, source
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                '175A', '2023', 'Q1', '2023-03-31',
+                '2023-05-10', 90.0, 9.0, 6.0, 45.0, 'TEST_PREV'
+            ]
+        )
+        conn.commit()
+
+    yield
+    # 一時DBのため手動クリーンアップ不要
+
+
+class TestFiscalYearChangeQueries:
+    """決算期変更銘柄のクエリテスト"""
+
+    def test_get_detail_data_selects_latest_fiscal_end_date(self):
+        """get_detail_data()が最新fiscal_end_dateのレコードを返すこと"""
+        result = get_detail_data('175A', '2024-08-10')
+
+        # 累計実績が新決算期のデータ（revenue=150.0）を返すことを確認
+        assert result['cumulative'] is not None
+        assert result['cumulative']['revenue'] == 150.0
+        assert result['cumulative']['operating_income'] == 20.0
+        assert result['cumulative']['net_income'] == 15.0
+
+    def test_direct_query_returns_latest_record(self):
+        """financialsテーブルへの直接クエリでORDER BY fiscal_end_date DESCが動作すること"""
+        with get_connection() as conn:
+            cursor = conn.execute(
+                """
+                SELECT revenue, operating_income, fiscal_end_date, source
+                FROM financials
+                WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+                ORDER BY fiscal_end_date DESC LIMIT 1
+                """,
+                ['175A', '2024', 'Q1']
+            )
+            row = cursor.fetchone()
+
+        # 最新のfiscal_end_date（2024-06-30）のレコードが返ること
+        assert row['fiscal_end_date'] == '2024-06-30'
+        assert row['source'] == 'TEST_NEW'
+        assert row['revenue'] == 150.0
+        assert row['operating_income'] == 20.0
+
+    def test_view_query_with_order_by(self):
+        """v_financials_yoyビューへのクエリでORDER BY fiscal_end_dateが動作すること"""
+        with get_connection() as conn:
+            cursor = conn.execute(
+                """
+                SELECT revenue, fiscal_end_date
+                FROM v_financials_yoy
+                WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+                ORDER BY fiscal_end_date DESC LIMIT 1
+                """,
+                ['175A', '2024', 'Q1']
+            )
+            row = cursor.fetchone()
+
+        # ビューからも最新レコードが取得できること
+        assert row['fiscal_end_date'] == '2024-06-30'
+        assert row['revenue'] == 150.0
+
+    def test_without_order_by_returns_undefined(self):
+        """ORDER BYなしのクエリは不定のレコードを返すことを確認（検証用）"""
+        with get_connection() as conn:
+            cursor = conn.execute(
+                """
+                SELECT revenue, source
+                FROM financials
+                WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+                """,
+                ['175A', '2024', 'Q1']
+            )
+            rows = cursor.fetchall()
+
+        # 複数行が存在することを確認
+        assert len(rows) == 2
+        revenues = [r['revenue'] for r in rows]
+        assert 100.0 in revenues
+        assert 150.0 in revenues

--- a/tests/test_standalone_quarter_fix.py
+++ b/tests/test_standalone_quarter_fix.py
@@ -23,7 +23,8 @@ class TestHasPrevQuarterFlag:
         upsert_company("8001", "テスト社A")
         insert_financial("8001", "2024", "Q1",
                          revenue=100.0, operating_income=10.0,
-                         ordinary_income=9.0, net_income=7.0, source="TEST")
+                         ordinary_income=9.0, net_income=7.0, source="TEST",
+                         fiscal_end_date="2023-06-30")
 
         with get_connection() as conn:
             row = conn.execute(
@@ -37,7 +38,8 @@ class TestHasPrevQuarterFlag:
         upsert_company("8002", "テスト社B")
         insert_financial("8002", "2024", "Q2",
                          revenue=200.0, operating_income=20.0,
-                         ordinary_income=18.0, net_income=14.0, source="TEST")
+                         ordinary_income=18.0, net_income=14.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         with get_connection() as conn:
             row = conn.execute(
@@ -53,10 +55,12 @@ class TestHasPrevQuarterFlag:
         upsert_company("8003", "テスト社C")
         insert_financial("8003", "2024", "Q1",
                          revenue=100.0, operating_income=10.0,
-                         ordinary_income=9.0, net_income=7.0, source="TEST")
+                         ordinary_income=9.0, net_income=7.0, source="TEST",
+                         fiscal_end_date="2023-06-30")
         insert_financial("8003", "2024", "Q2",
                          revenue=220.0, operating_income=22.0,
-                         ordinary_income=20.0, net_income=15.0, source="TEST")
+                         ordinary_income=20.0, net_income=15.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         with get_connection() as conn:
             row = conn.execute(
@@ -71,10 +75,12 @@ class TestHasPrevQuarterFlag:
         upsert_company("8004", "テスト社D")
         insert_financial("8004", "2024", "Q1",
                          revenue=100.0, operating_income=10.0,
-                         ordinary_income=9.0, net_income=7.0, source="TEST")
+                         ordinary_income=9.0, net_income=7.0, source="TEST",
+                         fiscal_end_date="2023-06-30")
         insert_financial("8004", "2024", "Q3",
                          revenue=300.0, operating_income=30.0,
-                         ordinary_income=27.0, net_income=21.0, source="TEST")
+                         ordinary_income=27.0, net_income=21.0, source="TEST",
+                         fiscal_end_date="2023-12-31")
 
         with get_connection() as conn:
             rows = conn.execute(
@@ -96,7 +102,8 @@ class TestGetFinancialHistoryWithMissingPrev:
         insert_financial("8010", "2024", "Q2",
                          revenue=500.0, operating_income=50.0,
                          ordinary_income=45.0, net_income=35.0,
-                         eps=100.0, source="TEST")
+                         eps=100.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         result = get_financial_history("8010")
         assert len(result["quarterly"]) == 1
@@ -114,11 +121,13 @@ class TestGetFinancialHistoryWithMissingPrev:
         insert_financial("8011", "2024", "Q1",
                          revenue=100.0, operating_income=10.0,
                          ordinary_income=9.0, net_income=7.0,
-                         eps=50.0, source="TEST")
+                         eps=50.0, source="TEST",
+                         fiscal_end_date="2023-06-30")
         insert_financial("8011", "2024", "Q2",
                          revenue=230.0, operating_income=25.0,
                          ordinary_income=22.0, net_income=17.0,
-                         eps=85.0, source="TEST")
+                         eps=85.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         result = get_financial_history("8011")
         labels = [r["label"] for r in result["quarterly"]]
@@ -136,14 +145,17 @@ class TestGetFinancialHistoryWithMissingPrev:
         # 2023: Q1+Q2あり（正常計算）
         insert_financial("8012", "2023", "Q1",
                          revenue=100.0, operating_income=10.0,
-                         ordinary_income=9.0, net_income=7.0, source="TEST")
+                         ordinary_income=9.0, net_income=7.0, source="TEST",
+                         fiscal_end_date="2022-06-30")
         insert_financial("8012", "2023", "Q2",
                          revenue=210.0, operating_income=21.0,
-                         ordinary_income=19.0, net_income=14.0, source="TEST")
+                         ordinary_income=19.0, net_income=14.0, source="TEST",
+                         fiscal_end_date="2022-09-30")
         # 2024: Q2のみ（Q1なし→「-」表示）
         insert_financial("8012", "2024", "Q2",
                          revenue=250.0, operating_income=25.0,
-                         ordinary_income=23.0, net_income=17.0, source="TEST")
+                         ordinary_income=23.0, net_income=17.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         result = get_financial_history("8012")
         quarterly = {r["label"]: r for r in result["quarterly"]}
@@ -161,14 +173,17 @@ class TestGetFinancialHistoryWithMissingPrev:
         # 2023: Q2のみ（Q1なし）
         insert_financial("8013", "2023", "Q2",
                          revenue=200.0, operating_income=20.0,
-                         ordinary_income=18.0, net_income=14.0, source="TEST")
+                         ordinary_income=18.0, net_income=14.0, source="TEST",
+                         fiscal_end_date="2022-09-30")
         # 2024: Q1+Q2あり
         insert_financial("8013", "2024", "Q1",
                          revenue=120.0, operating_income=12.0,
-                         ordinary_income=11.0, net_income=8.0, source="TEST")
+                         ordinary_income=11.0, net_income=8.0, source="TEST",
+                         fiscal_end_date="2023-06-30")
         insert_financial("8013", "2024", "Q2",
                          revenue=260.0, operating_income=26.0,
-                         ordinary_income=24.0, net_income=18.0, source="TEST")
+                         ordinary_income=24.0, net_income=18.0, source="TEST",
+                         fiscal_end_date="2023-09-30")
 
         result = get_financial_history("8013")
         quarterly = {r["label"]: r for r in result["quarterly"]}

--- a/web/services/financial_service.py
+++ b/web/services/financial_service.py
@@ -118,6 +118,7 @@ def get_viewer_data(
                            ordinary_income, ordinary_income_prev_year
                     FROM v_financials_yoy
                     WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+                    ORDER BY fiscal_end_date DESC LIMIT 1
                 """,
                     [ticker, fy, fq],
                 )
@@ -157,6 +158,7 @@ def get_viewer_data(
                         FROM v_financials_standalone_quarter
                         WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
                               AND has_prev_quarter = 1
+                        ORDER BY announcement_date DESC LIMIT 1
                     """,
                         [ticker, fy, fq],
                     )
@@ -170,6 +172,7 @@ def get_viewer_data(
                         FROM v_financials_standalone_quarter
                         WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
                               AND has_prev_quarter = 1
+                        ORDER BY announcement_date DESC LIMIT 1
                     """,
                         [ticker, prev_fy_q, prev_fq],
                     )
@@ -280,6 +283,7 @@ def get_detail_data(ticker_code: str, target_date: str) -> dict:
             SELECT revenue, gross_profit, operating_income, ordinary_income, net_income
             FROM financials
             WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+            ORDER BY fiscal_end_date DESC LIMIT 1
         """,
             [ticker_code, fy, fq],
         )
@@ -292,6 +296,7 @@ def get_detail_data(ticker_code: str, target_date: str) -> dict:
                 SELECT revenue, gross_profit, operating_income, ordinary_income, net_income
                 FROM financials
                 WHERE ticker_code = ? AND fiscal_year = ? AND fiscal_quarter = ?
+                ORDER BY fiscal_end_date DESC LIMIT 1
             """,
                 [ticker_code, prev_fy, fq],
             )
@@ -650,7 +655,7 @@ def get_financial_history(ticker_code: str) -> dict:
                 FROM financials
                 WHERE ticker_code = ? AND fiscal_year = ?
                       AND fiscal_quarter = 'FY'
-                LIMIT 1
+                ORDER BY fiscal_end_date DESC LIMIT 1
                 """,
                 [ticker_code, str(int(fc_fy) - 1)],
             )
@@ -664,7 +669,7 @@ def get_financial_history(ticker_code: str) -> dict:
                     FROM financials
                     WHERE ticker_code = ? AND fiscal_year = ?
                           AND fiscal_quarter = 'Q4'
-                    LIMIT 1
+                    ORDER BY fiscal_end_date DESC LIMIT 1
                     """,
                     [ticker_code, str(int(fc_fy) - 1)],
                 )


### PR DESCRIPTION
## Summary
- 決算期変更銘柄（175A, 4331, 4891, 6630）でTDnetレコードがEDINETに上書きされる問題を修正
- `fiscal_end_date`をUNIQUE制約に追加し、異なる決算期末日のレコードを別行として保持
- Web層で複数行存在時に最新の`fiscal_end_date`を優先するクエリに修正

## Changes
- **DB**: `UNIQUE(ticker_code, fiscal_year, fiscal_quarter)` → `UNIQUE(ticker_code, fiscal_year, fiscal_quarter, fiscal_end_date)`
- **db_utils.py**: `insert_financial()`でfiscal_end_date必須化、ON CONFLICT/優先度チェック4カラム化
- **fetch_tdnet.py**: `detect_fiscal_end_date_from_title()`追加（iXBRL取得失敗時のフォールバック）
- **financial_service.py**: 7箇所のクエリにORDER BY fiscal_end_date DESC LIMIT 1追加
- **schema.sql**: NOT NULL制約、ビューのWINDOW ORDER BY変更
- **マイグレーション**: V007追加（テーブル再作成方式）

## Test plan
- [x] 全287テスト通過（新規テスト含む）
- [x] 決算期変更時のUNIQUE制約テスト（TestFiscalYearChangeHandling）
- [x] タイトルからのfiscal_end_date推定テスト（TestDetectFiscalEndDateFromTitle）
- [x] Web層の最新fiscal_end_date優先テスト（TestFiscalYearChangeQueries）
- [x] 175Aの再取得による手動検証（fetch_tdnet.py → fetch_financials.py）

🤖 Generated with [Claude Code](https://claude.com/claude-code)