### PR TITLE
fix: TDnet決算短信のXBRLマッピング漏れ8件を追加

### DIFF
--- a/scripts/fetch_financials.py
+++ b/scripts/fetch_financials.py
@@ -191,6 +191,17 @@ XBRL_FACT_MAPPING_IFRS = {
     'NetIncomeUS': 'net_income',                           # TDnet US-GAAP純利益（tse-ed-t）
     # TDnet 営業利益（tse-ed-t名前空間）
     'OperatingIncomeUS': 'operating_income',  # TDnet US-GAAP営業利益（tse-ed-t）
+    # TDnet 売上高 追加（tse-ed-t名前空間）
+    'Revenue2': 'revenue',                    # 新収益認識基準の売上高（博報堂DY等）
+    'OperatingRevenuesSpecific': 'revenue',   # 特殊業種の営業収益
+    'GrossOperatingRevenues': 'revenue',      # 総営業収益
+    'OperatingRevenuesUS': 'revenue',         # US-GAAP営業収益
+    # TDnet 証券業 純営業収益（tse-ed-t名前空間）
+    'NetOperatingRevenuesSE': 'gross_profit', # 証券業の純営業収益
+    # TDnet US-GAAP EPS（tse-ed-t名前空間）
+    'DilutedNetIncomePerShareUS': 'eps',      # US-GAAP希薄化後EPS
+    'DilutedNetIncomePerShare2US': 'eps',     # US-GAAP希薄化後EPS (v2)
+    'BasicNetIncomePerShareUS': 'eps',        # US-GAAP基本的EPS
 }
 
 # レガシーパーサー用: 財務項目のXBRLタグ（日本基準）


### PR DESCRIPTION
## 概要

TDnet決算短信の「一部欠損」ログ330件を調査した結果、`XBRL_FACT_MAPPING_IFRS` に8件のマッピング漏れを特定し、修正しました。

## 変更内容

### 追加したマッピング（8件）

#### 売上高系（4件）
- `Revenue2` → `revenue`（新収益認識基準の売上高）
  - 該当企業例: 博報堂DYホールディングス
- `OperatingRevenuesSpecific` → `revenue`（特殊業種の営業収益）
- `GrossOperatingRevenues` → `revenue`（総営業収益）
- `OperatingRevenuesUS` → `revenue`（US-GAAP営業収益）

#### 証券業（1件）
- `NetOperatingRevenuesSE` → `gross_profit`（証券業純営業収益）

#### US-GAAP EPS（3件）
- `DilutedNetIncomePerShareUS` → `eps`（希薄化後EPS）
- `DilutedNetIncomePerShare2US` → `eps`（希薄化後EPS v2）
- `BasicNetIncomePerShareUS` → `eps`（基本的EPS）

すべて `tse-ed-t` 名前空間の要素で、TDnet決算短信専用のタグです。

## 調査経緯

1. `logs/fetch_financials.log` から「一部欠損」が記録された330件のTDnet決算短信を抽出
2. 各ログの `[DEBUG] 未マッチXBRL要素` を分析し、頻出パターンを特定
3. 該当企業の実XBRLファイルを確認し、要素名とコンテキストを検証
4. マッピング定義を追加

## テスト

- 全テスト307件が通過済み（`pytest` 実行済み）
- 既存マッピングには影響なし

## 影響範囲

- TDnet決算短信のXBRL取得精度が向上
- 特に博報堂DYホールディングスなど新収益認識基準適用企業、US-GAAP企業、証券業企業のデータ取得が改善

🤖 Generated with [Claude Code](https://claude.com/claude-code)