### PR TITLE
fix: XBRL売上高・売上総利益のマッピング漏れ14件を追加

### DIFF
--- a/.claude/rules/xbrl-taxonomy.md
+++ b/.claude/rules/xbrl-taxonomy.md
@@ -41,6 +41,7 @@ EDINET/TDnetのXBRL財務データパースでは、会計基準・業種ごと�
 | `OrdinaryIncomeINS` | 保険業（経常収益） |
 | `OperatingIncomeINS` | 保険業（営業収益）※名前は紛らわしいが売上相当 |
 | `TotalOperatingRevenue` | 営業収益合計 |
+| `GrossOperatingRevenue` | 営業総収入（コンビニ・小売・サービス業） |
 
 ### IFRS
 | 要素名 | 説明 |
@@ -65,6 +66,12 @@ EDINET/TDnetのXBRL財務データパースでは、会計基準・業種ごと�
 ### 有報 経営指標サマリー (jpcrp_cor)
 P/L本表とは別に、有報の「経営指標等の推移」セクションにも売上高が記載される。
 要素名は `*SummaryOfBusinessResults` サフィックス付き（例: `NetSalesSummaryOfBusinessResults`）。
+
+| 要素名 | 説明 |
+|---|---|
+| `NetSalesSummaryOfBusinessResults` | 売上高 |
+| `GrossOperatingRevenueSummaryOfBusinessResults` | 営業総収入（コンビニ・小売等） |
+| `OperatingRevenuesSummaryOfBusinessResults` | 営業収益（航空業等） |
 
 ### IFRS有報サマリー (jpcrp_cor)
 
@@ -197,6 +204,7 @@ US-GAAP採用企業（オムロン、野村HD、富士フイルム等）の有�
 | `NetOperatingRevenueSEC` | 第一種金融商品取引業（純営業収益） |
 | `OperatingGrossProfit` | 一般商工業（営業総利益） |
 | `OperatingGrossProfitWAT` | 海運業（営業総利益） |
+| `GrossProfitBusiness` | 事業利益（航空業等） |
 
 ### IFRS
 | 要素名 | 説明 |
@@ -219,6 +227,7 @@ US-GAAP採用企業（オムロン、野村HD、富士フイルム等）の有�
 - IFRSには「経常利益」がない → `ProfitLossBeforeTax`（税引前利益）を `ordinary_income` にマッピング
 - 検索順序: `XBRL_FACT_MAPPING` → `XBRL_FACT_MAPPING_IFRS`（最初にマッチした値を優先）
 - コンテキスト判定: `CurrentYearDuration` / `InterimPeriodDuration` 等が当期データ、`Prior*` は前期
+- **会社固有拡張タクソノミ**: 企業ごとに独自の要素名（`GrossSales`, `RevenueRevOA` 等）が使われる場合があり、これらもマッピングに追加している。数が増えるため上記テーブルには網羅的に記載していないが、未マッチログから必要に応じて追加する
 
 ## 構造的欠損（修正不要）
 

--- a/scripts/fetch_financials.py
+++ b/scripts/fetch_financials.py
@@ -86,6 +86,9 @@ XBRL_FACT_MAPPING = {
     'OperatingRevenueINV': 'revenue',                              # 投資業
     'OperatingRevenueIVT': 'revenue',                              # IVT業
     'OperatingRevenueCMD': 'revenue',                              # CMD業
+    'GrossOperatingRevenue': 'revenue',                            # 営業総収入（コンビニ・小売・サービス業）
+    'GrossSales': 'revenue',                                       # 総売上高（広告代理店等）
+    'RevenueRevOA': 'revenue',                                     # 収益（博報堂DY等）
     # 売上高（有価証券報告書 経営指標サマリー - jpcrp_cor）
     'NetSalesSummaryOfBusinessResults': 'revenue',
     'OperatingRevenue1SummaryOfBusinessResults': 'revenue',
@@ -95,6 +98,8 @@ XBRL_FACT_MAPPING = {
     'BusinessRevenueSummaryOfBusinessResults': 'revenue',
     'OrdinaryIncomeBNKSummaryOfBusinessResults': 'revenue',
     'OrdinaryIncomeINSSummaryOfBusinessResults': 'revenue',      # 保険業（有報サマリー）
+    'GrossOperatingRevenueSummaryOfBusinessResults': 'revenue',  # 営業総収入（コンビニ・小売等）
+    'OperatingRevenuesSummaryOfBusinessResults': 'revenue',      # 営業収益（航空業等）
     'RevenueIFRSSummaryOfBusinessResults': 'revenue',            # IFRS企業の有報
     'RevenuesUSGAAPSummaryOfBusinessResults': 'revenue',         # US-GAAP企業の有報
     # 売上総利益
@@ -105,6 +110,7 @@ XBRL_FACT_MAPPING = {
     'NetOperatingRevenueSEC': 'gross_profit',                        # 第一種金融商品取引業（純営業収益）
     'OperatingGrossProfit': 'gross_profit',                          # 一般商工業（営業総利益）
     'OperatingGrossProfitWAT': 'gross_profit',                       # 海運業（営業総利益）
+    'GrossProfitBusiness': 'gross_profit',                             # 事業利益（航空業等）
     # 営業利益
     'OperatingIncome': 'operating_income',
     'OperatingProfit': 'operating_income',

--- a/tests/test_fetch_financials.py
+++ b/tests/test_fetch_financials.py
@@ -104,6 +104,9 @@ class TestXbrlFactMapping:
             'BusinessRevenue', 'TotalOperatingRevenue',
             'OrdinaryIncomeBNK',
             'OperatingRevenueINV', 'OperatingRevenueIVT', 'OperatingRevenueCMD',
+            'GrossOperatingRevenue',  # 営業総収入（コンビニ・小売・サービス業）
+            'GrossSales',             # 総売上高（広告代理店等）
+            'RevenueRevOA',           # 収益（博報堂DY等）
         ]
         for variant in industry_variants:
             assert XBRL_FACT_MAPPING[variant] == 'revenue', f"{variant} should map to revenue"
@@ -115,6 +118,8 @@ class TestXbrlFactMapping:
             'OperatingRevenue1SummaryOfBusinessResults',
             'RevenueIFRSSummaryOfBusinessResults',
             'RevenuesUSGAAPSummaryOfBusinessResults',
+            'GrossOperatingRevenueSummaryOfBusinessResults',  # 営業総収入（コンビニ・小売等）
+            'OperatingRevenuesSummaryOfBusinessResults',      # 営業収益（航空業等）
         ]
         for variant in summary_variants:
             assert XBRL_FACT_MAPPING[variant] == 'revenue', f"{variant} should map to revenue"
@@ -129,6 +134,7 @@ class TestXbrlFactMapping:
         assert XBRL_FACT_MAPPING['NetOperatingRevenueSEC'] == 'gross_profit'   # 第一種金融商品取引業
         assert XBRL_FACT_MAPPING['OperatingGrossProfit'] == 'gross_profit'     # 一般商工業（営業総利益）
         assert XBRL_FACT_MAPPING['OperatingGrossProfitWAT'] == 'gross_profit'  # 海運業
+        assert XBRL_FACT_MAPPING['GrossProfitBusiness'] == 'gross_profit'      # 事業利益（航空業等）
 
     def test_ifrs_revenue_variants(self):
         """IFRS売上高バリエーションが正しくマッピングされること"""


### PR DESCRIPTION
## Summary
- TDnet決算短信のXBRLマッピング漏れ8件を追加（前コミット）
- EDINET有報・半期報の売上高・売上総利益マッピング漏れ6件を追加
  - `GrossOperatingRevenue`（営業総収入）: **57社**に影響（コンビニ・小売・サービス業）
  - `GrossOperatingRevenueSummaryOfBusinessResults`（有報サマリー営業総収入）: 45件
  - `OperatingRevenuesSummaryOfBusinessResults`（有報サマリー営業収益）: 9件（航空業等）
  - `GrossSales`（総売上高）: セーラー広告等
  - `RevenueRevOA`（収益）: 博報堂DY等
  - `GrossProfitBusiness`（事業利益）: スカイマーク等

## Test plan
- [x] `pytest tests/test_fetch_financials.py` - 全69テスト通過
- [ ] `--days 1500 --force` 再取得で一部欠損WARNが減少することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)