### PR TITLE
refactor: レガシーXBRLパーサーを削除

### DIFF
--- a/tests/test_fetch_financials.py
+++ b/tests/test_fetch_financials.py
@@ -293,20 +293,6 @@ class TestExtractEdinetZip:
         finally:
             self._cleanup_result(result)
 
-    def test_extract_legacy_xbrl(self):
-        """旧形式の.xbrlファイルがフォールバックで検出されること"""
-        buf = io.BytesIO()
-        with zipfile.ZipFile(buf, 'w') as zf:
-            zf.writestr('XBRL/PublicDoc/report.xbrl', '<xbrli:xbrl></xbrli:xbrl>')
-
-        result = extract_edinet_zip(buf.getvalue())
-        try:
-            assert result is not None
-            assert isinstance(result, list)
-            assert result[0].suffix == '.xbrl'
-        finally:
-            self._cleanup_result(result)
-
     def test_extract_empty_zip(self):
         """XBRL関連ファイルのないZIPはNoneを返すこと"""
         buf = io.BytesIO()


### PR DESCRIPTION
## 概要

EDINET API v2 は全ドキュメントを iXBRL 形式（manifest.xml + .htm）で返すため、旧 `.xbrl` 形式向けのフォールバックパーサーはデッドコードになっていた。  
本PRでは該当コードを削除し、コードベースをスリム化する。

## 変更内容

- `scripts/fetch_financials.py`
  - `XBRL_TAGS_LEGACY` 定数を削除（旧 .xbrl 形式用タグマッピング辞書）
  - `_parse_xbrl_legacy()` 関数を削除（旧形式フォールバックパーサー）
  - `extract_xbrl_from_zip()` 内の `.xbrl` ファイル探索ロジックを削除
  - `process_document()` の else ブランチを、レガシーパーサー呼び出しから WARNING ログ出力に変更
- `tests/test_fetch_financials.py`
  - `test_extract_legacy_xbrl` テスト（削除された機能のテスト）を削除

## 削除規模

- 101行削除、2行追加（合計 -99行）

## テスト

- 既存テスト 375件 全て通過済み
- 削除したコードに対応するテストも合わせて削除

## 関連

- EDINET API v2 仕様: iXBRL 形式のみ提供（旧 .xbrl 形式は非対応）