### PR TITLE
refactor: EDINET展開時のtemp_dir検出ロジックを共通化

### DIFF
--- a/scripts/fetch_financials.py
+++ b/scripts/fetch_financials.py
@@ -42,6 +42,7 @@ from db_utils import (
     log_batch_start, log_batch_end,
     get_edinet_ticker_map, get_processed_doc_ids
 )
+from path_utils import find_edinet_temp_dir
 
 
 # EDINET API エンドポイント
@@ -993,16 +994,7 @@ def process_document(client: EdinetClient, doc_info: dict,
         return False
 
     # temp_dirを特定（クリーンアップ用）
-    # extracted_pathsはリスト、最初の要素からtemp_dirを特定
-    first_path = extracted_paths[0]
-    temp_dir = first_path
-    while temp_dir.parent != temp_dir and not str(temp_dir.name).startswith("edinet_"):
-        temp_dir = temp_dir.parent
-    # edinet_プレフィックスが見つからない場合はfirst_pathの最上位を使う
-    if not str(temp_dir.name).startswith("edinet_"):
-        temp_dir = first_path
-        while temp_dir.parent != temp_dir and temp_dir.parent != Path(tempfile.gettempdir()):
-            temp_dir = temp_dir.parent
+    temp_dir = find_edinet_temp_dir(extracted_paths)
 
     try:
         # パース方法を判定

--- a/scripts/fetch_tdnet.py
+++ b/scripts/fetch_tdnet.py
@@ -15,7 +15,6 @@ import json
 import re
 import shutil
 import sys
-import tempfile
 import time
 import unicodedata
 import zipfile
@@ -48,6 +47,7 @@ from db_utils import (
     is_valid_ticker_code,
     ticker_exists
 )
+from path_utils import find_edinet_temp_dir
 
 
 # ============================================
@@ -709,18 +709,6 @@ class TdnetClient:
 # メイン処理関数
 # ============================================
 
-def _find_temp_dir(extracted_paths: List[Path]) -> Path:
-    """extract_edinet_zip()が作成した一時ディレクトリのルートを特定"""
-    first_path = extracted_paths[0]
-    temp_dir = first_path
-    while temp_dir.parent != temp_dir and not str(temp_dir.name).startswith("edinet_"):
-        temp_dir = temp_dir.parent
-    if not str(temp_dir.name).startswith("edinet_"):
-        temp_dir = first_path
-        while temp_dir.parent != temp_dir and temp_dir.parent != Path(tempfile.gettempdir()):
-            temp_dir = temp_dir.parent
-    return temp_dir
-
 
 def _process_zip_to_db(
     zip_content: bytes, ticker_code: str, fiscal_year: str, fiscal_quarter: str,
@@ -749,7 +737,7 @@ def _process_zip_to_db(
     if not extracted_paths:
         return False
 
-    temp_dir = _find_temp_dir(extracted_paths)
+    temp_dir = find_edinet_temp_dir(extracted_paths)
 
     try:
         print(f"    パーサー: XBRLP (iXBRL)")

--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -1,0 +1,25 @@
+"""
+パス操作の共通ユーティリティ
+"""
+import tempfile
+from pathlib import Path
+
+
+def find_edinet_temp_dir(extracted_paths: list[Path]) -> Path:
+    """extract_edinet_zip() が生成した一時ディレクトリのルートを特定する。"""
+    if not extracted_paths:
+        raise ValueError("extracted_paths must not be empty")
+
+    first_path = extracted_paths[0]
+    temp_dir = first_path
+
+    while temp_dir.parent != temp_dir and not str(temp_dir.name).startswith("edinet_"):
+        temp_dir = temp_dir.parent
+
+    # edinet_ プレフィックスが見つからない場合は /tmp 直下まで遡る
+    if not str(temp_dir.name).startswith("edinet_"):
+        temp_dir = first_path
+        while temp_dir.parent != temp_dir and temp_dir.parent != Path(tempfile.gettempdir()):
+            temp_dir = temp_dir.parent
+
+    return temp_dir

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,30 @@
+"""
+path_utils.py のテスト
+"""
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from path_utils import find_edinet_temp_dir
+
+
+def test_find_edinet_temp_dir_with_edinet_prefix():
+    """edinet_プレフィックスがある場合、そのディレクトリを返すこと。"""
+    path = Path(tempfile.gettempdir()) / "edinet_abc123" / "XBRL" / "PublicDoc" / "sample.htm"
+    result = find_edinet_temp_dir([path])
+    assert result.name == "edinet_abc123"
+
+
+def test_find_edinet_temp_dir_without_edinet_prefix():
+    """edinet_プレフィックスがない場合、/tmp直下手前まで遡ること。"""
+    base = Path(tempfile.gettempdir()) / "work" / "nested"
+    path = base / "PublicDoc" / "sample.htm"
+    result = find_edinet_temp_dir([path])
+    assert result == Path(tempfile.gettempdir()) / "work"
+
+
+def test_find_edinet_temp_dir_empty_input():
+    """空リストは ValueError を返すこと。"""
+    with pytest.raises(ValueError):
+        find_edinet_temp_dir([])


### PR DESCRIPTION
## 概要
- `scripts/path_utils.py` に `find_edinet_temp_dir()` を新設
- `scripts/fetch_financials.py` と `scripts/fetch_tdnet.py` の重複していた temp_dir 探索処理を共通関数呼び出しへ置換
- `tests/test_path_utils.py` を追加し、`edinet_` あり/なし、空入力のケースを検証

## テスト
- `venv/bin/python -m pytest`
  - 結果: 417 passed, 2 skipped

Closes #52
