### PR TITLE
fix: Q1-Q3決算短信の業績予想データがDBに保存されないバグを修正

### DIFF
--- a/scripts/fetch_tdnet.py
+++ b/scripts/fetch_tdnet.py
@@ -839,6 +839,11 @@ def _process_zip_to_db(
             forecasts = parse_ixbrl_forecast(extracted_paths)
             if forecasts:
                 forecast_fy = _extract_forecast_fiscal_year(extracted_paths)
+                if fiscal_quarter in ('Q1', 'Q2', 'Q3'):
+                    # Q1-Q3: タイトル判定済み年度を信頼（XBRL抽出が不一致なら補正）
+                    if forecast_fy and forecast_fy != fiscal_year:
+                        print(f"    [補正] 予想年度: XBRL={forecast_fy} → タイトル={fiscal_year}")
+                    forecast_fy = fiscal_year
                 if forecast_fy:
                     for quarter, data in forecasts.items():
                         if any(v is not None for v in data.values()):


### PR DESCRIPTION
## 概要

Q1-Q3決算短信のTDnet XBRLから業績予想（会社予想）データがDBに保存されないバグを修正。

### 根本原因

`_is_forecast_context()` が `NextYear`/`NextAccumulatedQ2` のみ受け付けていたため、Q1-Q3短信の `CurrentYearDuration` 予想コンテキストが全て無視されていた。

## 変更内容

### `scripts/fetch_financials.py`

- `_is_forecast_context()`: `CurrentYearDuration`/`CurrentAccumulatedQ2Duration` を許可リストに追加。また `in` 検索を `startswith` に変更し `Next2YearDuration` 等の誤マッチを防止
- `XBRL_FORECAST_MAPPING`: `SalesIFRS`（IFRS売上高）を追加
- `_extract_forecast_fiscal_year()`: NextYear/NextQ2/CurrentYear/CurrentQ2 の4バケット方式に変更。`NextYearDuration` のみ早期breakとすることで、従来の `NextAccumulatedQ2Duration` 先行時に誤年度を返すバグも合わせて修正

### `scripts/fetch_tdnet.py`

- Q1-Q3はタイトル判定済み年度を常に使用し、XBRL抽出値と不一致の場合は補正ログを出力するよう変更

### `tests/test_forecast.py`

- 24件のテストを追加（計58件）: Q1-Q3コンテキスト許可・誤マッチ防止・NextQ2先行時の年度抽出・IFRS売上高マッピングなどのケースを網羅

## テスト

- `pytest tests/test_forecast.py` で全58件パス済み
- 修正対象の3ファイルすべてにテストが対応