### PR TITLE
refactor: XBRL共通関数をscripts/xbrl_common.pyに集約

### DIFF
--- a/.claude/agent-memory/data-layer-builder/MEMORY.md
+++ b/.claude/agent-memory/data-layer-builder/MEMORY.md
@@ -31,7 +31,7 @@ SOURCE_PRIORITY = {'EDINET': 3, 'TDnet': 2, 'JQuants': 2, 'yfinance': 1}
 ## fetch_financials.py パターン
 
 - 新関数の追加位置: `_parse_xbrl_legacy()` の前
-- 予想用: `XBRL_FORECAST_MAPPING`, `_is_forecast_context()`, `parse_ixbrl_forecast()`, `_extract_forecast_fiscal_year()`
+- 予想用: `XBRL_FORECAST_MAPPING`, `_is_forecast_context()`, `parse_ixbrl_forecast()`, `extract_forecast_fiscal_year()`（xbrl_common.py）
 - `_is_forecast_context()` は `NextYear`/`NextAccumulatedQ2` を含むコンテキストのみ対象
 - `ForecastMember` 判定に加えて `NextYear` の有無も確認（前期予想を除外）
 

--- a/.claude/rules/xbrl-taxonomy.md
+++ b/.claude/rules/xbrl-taxonomy.md
@@ -259,7 +259,7 @@ TDnet決算短信Summary iXBRLの業績予想データは `NextYearDuration` / `
 
 ### fiscal_year判定（TDnet XBRL）
 
-`_extract_forecast_fiscal_year()` が `NextYearDuration` を含むコンテキストの `endDate` をXMLから直接パースし、
+`extract_forecast_fiscal_year()`（`xbrl_common.py`）が `NextYearDuration` を含むコンテキストの `endDate` をXMLから直接パースし、
 その年部分（YYYY）を `fiscal_year` として使用する。
 
 ## マッピング追加の手順

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ stock_agent/
 TDnet決算短信 ZIP
   → fetch_tdnet.py (_process_zip_to_db)
     → parse_ixbrl_forecast()          # iXBRLから予想コンテキスト（NextYearDuration等）を抽出
-    → _extract_forecast_fiscal_year() # NextYearDurationのendDateから予想対象年度を特定
+    → extract_forecast_fiscal_year()  # NextYearDurationのendDateから予想対象年度を特定（xbrl_common.py）
     → insert_management_forecast()    # management_forecastsテーブルに保存
 ```
 

--- a/scripts/fetch_financials.py
+++ b/scripts/fetch_financials.py
@@ -44,6 +44,14 @@ from db_utils import (
 )
 from path_utils import find_edinet_temp_dir
 from env_utils import load_env
+from xbrl_common import (
+    wareki_to_seireki, extract_forecast_fiscal_year, WAREKI_MAP,
+)
+
+# 後方互換エイリアス（外部から _wareki_to_seireki / _extract_forecast_fiscal_year を
+# importしているコードが壊れないように維持）
+_wareki_to_seireki = wareki_to_seireki
+_extract_forecast_fiscal_year = extract_forecast_fiscal_year
 
 
 # EDINET API エンドポイント
@@ -704,72 +712,6 @@ def parse_ixbrl_financials(ixbrl_paths) -> Dict[str, Any]:
     return financials
 
 
-def _extract_forecast_fiscal_year(ixbrl_paths: list) -> Optional[str]:
-    """iXBRLのContext要素から予想対象の年度を抽出する。
-
-    NextYearDuration / CurrentYearDuration を含む予想コンテキスト
-    （ForecastMember必須）の endDate を取得し、
-    その年を fiscal_year 文字列として返す。
-    NextYear を優先し、なければ CurrentYear（Q1-Q3短信）にフォールバックする。
-
-    Args:
-        ixbrl_paths: iXBRLファイルのパスリスト
-
-    Returns:
-        年度文字列 (例: "2026") or None
-    """
-    for ixbrl_path in ixbrl_paths:
-        xbrli_ns = None
-        # 4バケット: NextYear / NextQ2 / CurrentYear / CurrentQ2 を個別管理
-        found_next_year = None
-        found_next_q2 = None
-        found_current_year = None
-        found_current_q2 = None
-
-        for event, elem in ET.iterparse(str(ixbrl_path), events=["start-ns", "end"]):
-            if event == "start-ns":
-                prefix, uri = elem
-                if uri == "http://www.xbrl.org/2003/instance":
-                    xbrli_ns = uri
-            elif event == "end" and xbrli_ns:
-                if elem.tag != f"{{{xbrli_ns}}}context":
-                    continue
-                ctx_id = elem.get("id", "")
-                # ForecastMember + Duration を含むコンテキストのみ対象
-                if "ForecastMember" not in ctx_id or "Duration" not in ctx_id:
-                    continue
-                period = elem.find(f"{{{xbrli_ns}}}period")
-                if period is None:
-                    continue
-                end_date = period.find(f"{{{xbrli_ns}}}endDate")
-                if end_date is None or not end_date.text:
-                    continue
-                date_text = end_date.text
-                # startswith で厳密にバケット振り分け（順序重要: Q2を先に判定）
-                if ctx_id.startswith("NextAccumulatedQ2Duration"):
-                    if not found_next_q2:
-                        found_next_q2 = date_text
-                elif ctx_id.startswith("NextYearDuration"):
-                    if not found_next_year:
-                        found_next_year = date_text
-                elif ctx_id.startswith("CurrentAccumulatedQ2Duration"):
-                    if not found_current_q2:
-                        found_current_q2 = date_text
-                elif ctx_id.startswith("CurrentYearDuration"):
-                    if not found_current_year:
-                        found_current_year = date_text
-                if found_next_year:
-                    break  # NextYearDuration = 最優先、早期終了
-
-        # 優先順位: NextYear > CurrentYear > NextQ2 > CurrentQ2
-        # Q2 endDateは年度末ではないため FY/CurrentYear を優先
-        best_date = found_next_year or found_current_year or found_next_q2 or found_current_q2
-        if best_date:
-            return best_date[:4]
-
-    return None
-
-
 def parse_ixbrl_forecast(ixbrl_paths) -> Dict[str, Dict[str, Any]]:
     """XBRLPを使ってiXBRLから業績予想データを抽出する。
 
@@ -887,25 +829,6 @@ def ticker_to_edinet_code(ticker_code: str) -> Optional[str]:
         )
         row = cursor.fetchone()
         return row['edinet_code'] if row else None
-
-
-WAREKI_MAP = {
-    '令和': 2018,  # 令和N年 = 2018 + N
-    '平成': 1988,  # 平成N年 = 1988 + N
-}
-
-
-def _wareki_to_seireki(text: str) -> str:
-    """和暦表記を西暦に変換する。
-
-    例: "令和7年12月期" → "2025年12月期"
-    """
-    for era, offset in WAREKI_MAP.items():
-        match = re.search(rf'{era}(\d{{1,2}})年', text)
-        if match:
-            year = offset + int(match.group(1))
-            return text[:match.start()] + f'{year}年' + text[match.end():]
-    return text
 
 
 # XBRLファイル名テンプレートコード → fiscal_quarter マッピング

--- a/scripts/fetch_tdnet.py
+++ b/scripts/fetch_tdnet.py
@@ -34,10 +34,9 @@ sys.path.insert(0, str(BASE_DIR / "lib"))
 from fetch_financials import (
     parse_ixbrl_financials,
     parse_ixbrl_forecast,
-    _extract_forecast_fiscal_year,
     extract_edinet_zip,
-    _wareki_to_seireki,
 )
+from xbrl_common import wareki_to_seireki, extract_forecast_fiscal_year
 
 from db_utils import (
     insert_financial,
@@ -101,7 +100,7 @@ def detect_fiscal_period(title: str, announcement_date: str) -> tuple:
     """
     # 全角数字→半角数字に正規化（TDnetは全角数字を使う場合がある）
     normalized_title = unicodedata.normalize('NFKC', title)
-    normalized_title = _wareki_to_seireki(normalized_title)
+    normalized_title = wareki_to_seireki(normalized_title)
 
     # 1. 年度を抽出
     fiscal_year = None
@@ -200,7 +199,7 @@ def detect_fiscal_end_date_from_title(title: str, fiscal_year: str, fiscal_quart
         "2024-12-31"
     """
     normalized = unicodedata.normalize('NFKC', title)
-    normalized = _wareki_to_seireki(normalized)
+    normalized = wareki_to_seireki(normalized)
 
     m = re.search(r'(\d{4})年(\d{1,2})月期', normalized)
     if not m:
@@ -826,7 +825,7 @@ def _process_zip_to_db(
         try:
             forecasts = parse_ixbrl_forecast(extracted_paths)
             if forecasts:
-                forecast_fy = _extract_forecast_fiscal_year(extracted_paths)
+                forecast_fy = extract_forecast_fiscal_year(extracted_paths)
                 if fiscal_quarter in ('Q1', 'Q2', 'Q3'):
                     # Q1-Q3: タイトル判定済み年度を信頼（XBRL抽出が不一致なら補正）
                     if forecast_fy and forecast_fy != fiscal_year:

--- a/scripts/xbrl_common.py
+++ b/scripts/xbrl_common.py
@@ -1,0 +1,94 @@
+"""XBRL解析共通ユーティリティ
+
+fetch_financials.py と fetch_tdnet.py で共有する
+XBRL関連のユーティリティ関数を提供する。
+"""
+import re
+import xml.etree.ElementTree as ET
+from typing import Optional
+
+
+# 和暦→西暦変換マップ
+WAREKI_MAP = {
+    '令和': 2018,  # 令和N年 = 2018 + N
+    '平成': 1988,  # 平成N年 = 1988 + N
+}
+
+
+def wareki_to_seireki(text: str) -> str:
+    """和暦表記を西暦に変換する。
+
+    例: "令和7年12月期" → "2025年12月期"
+    """
+    for era, offset in WAREKI_MAP.items():
+        match = re.search(rf'{era}(\d{{1,2}})年', text)
+        if match:
+            year = offset + int(match.group(1))
+            return text[:match.start()] + f'{year}年' + text[match.end():]
+    return text
+
+
+def extract_forecast_fiscal_year(ixbrl_paths: list) -> Optional[str]:
+    """iXBRLのContext要素から予想対象の年度を抽出する。
+
+    NextYearDuration / CurrentYearDuration を含む予想コンテキスト
+    （ForecastMember必須）の endDate を取得し、
+    その年を fiscal_year 文字列として返す。
+    NextYear を優先し、なければ CurrentYear（Q1-Q3短信）にフォールバックする。
+
+    Args:
+        ixbrl_paths: iXBRLファイルのパスリスト
+
+    Returns:
+        年度文字列 (例: "2026") or None
+    """
+    for ixbrl_path in ixbrl_paths:
+        xbrli_ns = None
+        # 4バケット: NextYear / NextQ2 / CurrentYear / CurrentQ2 を個別管理
+        found_next_year = None
+        found_next_q2 = None
+        found_current_year = None
+        found_current_q2 = None
+
+        for event, elem in ET.iterparse(str(ixbrl_path), events=["start-ns", "end"]):
+            if event == "start-ns":
+                prefix, uri = elem
+                if uri == "http://www.xbrl.org/2003/instance":
+                    xbrli_ns = uri
+            elif event == "end" and xbrli_ns:
+                if elem.tag != f"{{{xbrli_ns}}}context":
+                    continue
+                ctx_id = elem.get("id", "")
+                # ForecastMember + Duration を含むコンテキストのみ対象
+                if "ForecastMember" not in ctx_id or "Duration" not in ctx_id:
+                    continue
+                period = elem.find(f"{{{xbrli_ns}}}period")
+                if period is None:
+                    continue
+                end_date = period.find(f"{{{xbrli_ns}}}endDate")
+                if end_date is None or not end_date.text:
+                    continue
+                date_text = end_date.text
+                # startswith で厳密にバケット振り分け（順序重要: Q2を先に判定）
+                if ctx_id.startswith("NextAccumulatedQ2Duration"):
+                    if not found_next_q2:
+                        found_next_q2 = date_text
+                elif ctx_id.startswith("NextYearDuration"):
+                    if not found_next_year:
+                        found_next_year = date_text
+                elif ctx_id.startswith("CurrentAccumulatedQ2Duration"):
+                    if not found_current_q2:
+                        found_current_q2 = date_text
+                elif ctx_id.startswith("CurrentYearDuration"):
+                    if not found_current_year:
+                        found_current_year = date_text
+                if found_next_year:
+                    break  # NextYearDuration = 最優先、早期終了
+
+        # 優先順位: NextYear > CurrentYear > NextQ2 > CurrentQ2
+        # Q2 endDateは年度末ではないため FY/CurrentYear を優先
+        best_date = found_next_year or found_current_year or found_next_q2 or found_current_q2
+        if best_date:
+            return best_date[:4]
+
+    return None

--- a/tests/test_fetch_financials.py
+++ b/tests/test_fetch_financials.py
@@ -24,8 +24,11 @@ from fetch_financials import (
     _detect_fiscal_year,
     _detect_quarter_from_xbrl_filename,
     _extract_fiscal_end_date_from_xbrl,
+    _wareki_to_seireki,
+    _extract_forecast_fiscal_year,
     extract_edinet_zip,
 )
+from xbrl_common import wareki_to_seireki, extract_forecast_fiscal_year
 from xbrlp import QName
 
 
@@ -683,3 +686,13 @@ class TestExtractFiscalEndDateFromXbrl:
 </html>'''
         p = self._write_ixbrl(tmp_path, ixbrl)
         assert _extract_fiscal_end_date_from_xbrl([p]) == "2025-09-30"
+
+
+class TestBackwardCompatAliases:
+    """xbrl_common.py移設後の後方互換エイリアスが正しく動作することを確認"""
+
+    def test_wareki_alias_is_same_function(self):
+        assert _wareki_to_seireki is wareki_to_seireki
+
+    def test_forecast_fiscal_year_alias_is_same_function(self):
+        assert _extract_forecast_fiscal_year is extract_forecast_fiscal_year

--- a/tests/test_fetch_tdnet.py
+++ b/tests/test_fetch_tdnet.py
@@ -25,7 +25,7 @@ from fetch_tdnet import (
     _pick_ix_value,
     _load_or_fetch_announcements,
 )
-from fetch_financials import _wareki_to_seireki
+from xbrl_common import wareki_to_seireki
 from db_utils import get_connection, insert_financial, insert_announcement
 
 
@@ -202,19 +202,19 @@ class TestWarekiToSeireki:
     """和暦→西暦変換のテスト"""
 
     def test_reiwa(self):
-        assert _wareki_to_seireki("令和7年12月期") == "2025年12月期"
+        assert wareki_to_seireki("令和7年12月期") == "2025年12月期"
 
     def test_reiwa_double_digit(self):
-        assert _wareki_to_seireki("令和10年3月期") == "2028年3月期"
+        assert wareki_to_seireki("令和10年3月期") == "2028年3月期"
 
     def test_heisei(self):
-        assert _wareki_to_seireki("平成31年3月期") == "2019年3月期"
+        assert wareki_to_seireki("平成31年3月期") == "2019年3月期"
 
     def test_no_wareki(self):
-        assert _wareki_to_seireki("2025年3月期") == "2025年3月期"
+        assert wareki_to_seireki("2025年3月期") == "2025年3月期"
 
     def test_no_year(self):
-        assert _wareki_to_seireki("決算短信") == "決算短信"
+        assert wareki_to_seireki("決算短信") == "決算短信"
 
 
 class TestDataSourcePriority:


### PR DESCRIPTION
## Summary

- `scripts/xbrl_common.py` を新規作成し、`fetch_financials.py` のprivate関数 `_wareki_to_seireki` / `_extract_forecast_fiscal_year` をpublic関数として移動
- `fetch_financials.py` に後方互換エイリアスを追加し、既存コードへの影響を最小化
- `fetch_tdnet.py` のimportを `xbrl_common` モジュールに変更し、private関数への直接依存を解消
- テスト・ドキュメントを更新

Closes #53

## Test plan

- [ ] `venv/bin/python -m pytest` で全463テストがパスすることを確認済み
- [ ] `fetch_financials.py` の後方互換エイリアス（`_wareki_to_seireki`, `_extract_forecast_fiscal_year`）が動作すること
- [ ] `fetch_tdnet.py` が `xbrl_common` からの関数で正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)