### PR TITLE
feat: デプロイ時にsystemdでWebサーバーを自動起動

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no \
             ${{ env.VM_USER }}@${{ env.VM_HOST }} << 'EOF'
+          set -euo pipefail
           cd ${{ env.DEPLOY_PATH }}
 
           # Python仮想環境がなければ作成
@@ -63,6 +64,15 @@ jobs:
           # マイグレーション適用（新規・既存環境どちらも対応）
           python scripts/migrate.py apply
           echo "Database migrations applied"
+
+          # Webサーバー（systemd）のセットアップ・再起動
+          sudo -n cp infra/stock-agent-web.service /etc/systemd/system/
+          sudo -n systemctl daemon-reload
+          sudo -n systemctl enable stock-agent-web
+          sudo -n systemctl restart stock-agent-web
+          sleep 2
+          sudo -n systemctl is-active --quiet stock-agent-web
+          echo "Web server restarted"
 
           echo "Deployment completed successfully!"
           EOF

--- a/infra/stock-agent-web.service
+++ b/infra/stock-agent-web.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Stock Agent Web (FastAPI + uvicorn)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=azureuser
+Group=azureuser
+WorkingDirectory=/home/azureuser/stock_agent
+EnvironmentFile=-/home/azureuser/stock_agent/.env
+Environment=PATH=/home/azureuser/stock_agent/venv/bin:/usr/bin:/bin
+ExecStart=/home/azureuser/stock_agent/venv/bin/uvicorn web.app:app --host 0.0.0.0 --port 8000
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- `infra/stock-agent-web.service` 新規追加（uvicorn systemdユニットファイル）
- `deploy.yml` にsystemdセットアップ・再起動ステップを追加
- `deploy.yml` の Setup on remote server に `set -euo pipefail` を追加

## Test plan
- [ ] マージ後、GitHub Actionsのデプロイが成功することを確認
- [ ] Azure VM上で `systemctl status stock-agent-web` が active であることを確認
- [ ] Playwrightで http://20.222.241.22:8000/ にアクセスし画面表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)